### PR TITLE
Support the Windows platform

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python: [3.7, 3.8, 3.9]
     steps: 
       - name: Check out code

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -5,25 +5,15 @@
     <inspection_tool class="DuplicatedCode" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="GrazieInspection" enabled="false" level="TYPO" enabled_by_default="false" />
     <inspection_tool class="LanguageDetectionInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyArgumentEqualDefaultInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
-    <inspection_tool class="PyAugmentAssignmentInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="PyBDDParametersInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyBroadExceptionInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="PyCallByClassInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="PyClassicStyleClassInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="PyCompatibilityInspection" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="ourVersions">
-        <value>
-          <list size="2">
-            <item index="0" class="java.lang.String" itemvalue="2.7" />
-            <item index="1" class="java.lang.String" itemvalue="3.10" />
-          </list>
-        </value>
-      </option>
-    </inspection_tool>
-    <inspection_tool class="PyMandatoryEncodingInspection" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="PyMissingOrEmptyDocstringInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
-    <inspection_tool class="PyMissingTypeHintsInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
-    <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+    <inspection_tool class="PyDefaultArgumentInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyDictCreationInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyListCreationInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyMethodMayBeStaticInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyPep8Inspection" enabled="false" level="WEAK WARNING" enabled_by_default="false">
       <option name="ignoredErrors">
         <list>
           <option value="E231" />
@@ -31,13 +21,22 @@
         </list>
       </option>
     </inspection_tool>
-    <inspection_tool class="PyPep8NamingInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+    <inspection_tool class="PyPep8NamingInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false">
       <option name="ignoredErrors">
         <list>
           <option value="N806" />
         </list>
       </option>
     </inspection_tool>
+    <inspection_tool class="PyProtectedMemberInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyRedundantParenthesesInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyShadowingBuiltinsInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyShadowingNamesInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PySimplifyBooleanCheckInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyUnboundLocalVariableInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyUnusedLocalInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="RegExpDuplicateAlternationBranch" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
       <option name="processCode" value="true" />
       <option name="processLiterals" value="true" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,59 +1,29 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
-    <inspection_tool class="CommandLineInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="CythonUsageBeforeDeclarationInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="DuplicatedCode" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyAbstractClassInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyArgumentListInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyAssignmentToLoopOrWithParameterInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyAsyncCallInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyAttributeOutsideInitInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="GrazieInspection" enabled="false" level="TYPO" enabled_by_default="false" />
+    <inspection_tool class="LanguageDetectionInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="PyArgumentEqualDefaultInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyAugmentAssignmentInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="PyBDDParametersInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyBroadExceptionInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyByteLiteralInspection" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PyCallByClassInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyCallingNonCallableInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyChainedComparisonsInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyClassHasNoInitInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyComparisonWithNoneInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyDataclassInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyDecoratorInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyDefaultArgumentInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyDeprecationInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyDictCreationInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyDictDuplicateKeysInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyDocstringTypesInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyDunderSlotsInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyExceptClausesOrderInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyExceptionInheritInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyFinalInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyFromFutureImportInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyGlobalUndefinedInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyInconsistentIndentationInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyIncorrectDocstringInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyInitNewSignatureInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyInterpreterInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyListCreationInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyMethodFirstArgAssignmentInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyMethodMayBeStaticInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyMethodOverridingInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyMethodParametersInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyMissingConstructorInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyNamedTupleInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyNestedDecoratorsInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyNonAsciiCharInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyNoneFunctionAssignmentInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyOldStyleClassesInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyOverloadsInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyPackageRequirementsInspection" enabled="false" level="WARNING" enabled_by_default="false">
-      <option name="ignoredPackages">
+    <inspection_tool class="PyClassicStyleClassInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyCompatibilityInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ourVersions">
         <value>
-          <list size="0" />
+          <list size="2">
+            <item index="0" class="java.lang.String" itemvalue="2.7" />
+            <item index="1" class="java.lang.String" itemvalue="3.10" />
+          </list>
         </value>
       </option>
     </inspection_tool>
-    <inspection_tool class="PyPep8Inspection" enabled="false" level="WEAK WARNING" enabled_by_default="false">
+    <inspection_tool class="PyMandatoryEncodingInspection" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyMissingOrEmptyDocstringInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyMissingTypeHintsInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="ignoredErrors">
         <list>
           <option value="E231" />
@@ -61,43 +31,13 @@
         </list>
       </option>
     </inspection_tool>
-    <inspection_tool class="PyPep8NamingInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false">
+    <inspection_tool class="PyPep8NamingInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="ignoredErrors">
         <list>
           <option value="N806" />
         </list>
       </option>
     </inspection_tool>
-    <inspection_tool class="PyPropertyAccessInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyPropertyDefinitionInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyProtectedMemberInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyProtocolInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyRedeclarationInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyRedundantParenthesesInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyReturnFromInitInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PySetFunctionToLiteralInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyShadowingBuiltinsInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyShadowingNamesInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PySimplifyBooleanCheckInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PySingleQuotedDocstringInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyStatementEffectInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyStringExceptionInspection" enabled="false" level="ERROR" enabled_by_default="false" />
-    <inspection_tool class="PyStringFormatInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyStubPackagesAdvertiser" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyStubPackagesCompatibilityInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PySuperArgumentsInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyTestParametrizedInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyTrailingSemicolonInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyTupleAssignmentBalanceInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyTupleItemAssignmentInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyTypeCheckerInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyTypeHintsInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyTypedDictInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyUnboundLocalVariableInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyUnnecessaryBackslashInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyUnreachableCodeInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyUnusedLocalInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
       <option name="processCode" value="true" />
       <option name="processLiterals" value="true" />

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,6 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <settings>
-    <option name="USE_PROJECT_PROFILE" value="false" />
-    <version value="1.0" />
-  </settings>
-</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: system
         name: isort
-        entry: poetry run isort src/**/*.py tests/*.py
+        entry: poetry run isort src/**/**/*.py tests/*.py
         pass_filenames: false
         language: system
   - repo: local

--- a/.toxrc
+++ b/.toxrc
@@ -6,6 +6,7 @@ envlist =
 ignore_basepython_conflict = true
 
 [testenv]
+passenv = USERNAME   # See: https://github.com/tox-dev/tox/issues/1455 and https://github.com/gitpython-developers/GitPython/issues/356
 whitelist_externals = poetry
 commands =
    nocoverage: poetry run python -m unittest discover -s tests -t tests

--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,7 @@
 Version 3.5.0     unreleased
 
 	* Changes to support the Windows platform, for the first time since 3.0.1.
+	* Minor tweaks to the codebase to make the PyCharm code inspector happy.
 
 Version 3.4.1     20 Dec 2020
 

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 3.5.0     unreleased
+
+	* Changes to support the Windows platform, for the first time since 3.0.1.
+
 Version 3.4.1     20 Dec 2020
 
 	* Fix Python dependencies to work with Python 3.9.1 and not just 3.9.0.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -221,7 +221,7 @@ Under **Project Structure**, mark both `src` and `tests` as source folders.  In 
 **Exclude Files** box, enter the following:
 
 ```
-.coverage;.coveragerc;.github;.htmlcov;.idea;.isort.cfg;.pre-commit-config.yaml;.pylintrc;.pytest_cache;.readthedocs.yml;.tox;.toxrc;build;dist;docs/_build;out;poetry.lock;run
+.coverage;.coveragerc;.github;.htmlcov;.idea;.isort.cfg;.pre-commit-config.yaml;.pylintrc;.pytest_cache;.readthedocs.yml;.tox;.toxrc;build;dist;docs/_build;out;poetry.lock;run;tools.ps1
 ```
 
 Finally, go to the gear icon in the project panel, and uncheck **Show Excluded
@@ -248,7 +248,7 @@ Still on the **Sources** tab, find the **Exclude files** box.  Enter the
 following, and click **Apply**:
 
 ```
-.coverage;.coveragerc;.github;.htmlcov;.idea;.isort.cfg;.pre-commit-config.yaml;.pylintrc;.pytest_cache;.readthedocs.yml;.tox;.toxrc;build;dist;docs/_build;out;poetry.lock;run
+.coverage;.coveragerc;.github;.htmlcov;.idea;.isort.cfg;.pre-commit-config.yaml;.pylintrc;.pytest_cache;.readthedocs.yml;.tox;.toxrc;build;dist;docs/_build;out;poetry.lock;run;tools.ps1
 ```
 
 On the **Dependencies** tab, select the Python SDK you configured above as the

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -3,10 +3,9 @@
 ## Development Environment
 
 This code has been around since the early 2000s.  Historically, my development
-environment has been Vim on Debian Linux.  Recently, I've also begun using
-IntelliJ on MacOS.  As of now, I do not do any software development on Windows.
-It's not clear whether the code works there. (I haven't tried using it on
-Windows since ~2005.)
+environment has been Vim on Debian Linux.  In 2020, I worked on this code using
+IntelliJ Ultimate on MacOS and also got it working in a Windows 10 development
+environment using PyCharm.
 
 ## Packaging and Dependencies
 
@@ -61,6 +60,19 @@ Then, install Poetry in your home directory:
 ```
 $ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
 ```
+
+### Windows
+
+First, install Python 3 from your preferred source, either a standard
+installer or a meta-installer like Chocolatey.  Then, install Poetry
+in your home directory:
+
+```
+$ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+```
+
+The development environment (with the `run` script, etc.) expects a bash shell
+to be available.  It works fine with the standard Git bash.
 
 ## Configure Poetry's Python Interpreter
 
@@ -151,15 +163,15 @@ These are the exact scripts published by Poetry as part of the Python package.
 
 ## Integration with IntelliJ or PyCharm
 
-For my day-to-day IDE, I often use IntelliJ Ultimate with the Python plugin
-installed, which is basically equivalent to PyCharm. By integrating Black and
-Pylint, most everything important that can be done from a shell environment can
-also be done right in IntelliJ.
+I have used both PyCharm and IntelliJ Ultimate (with the Python plugin
+installed).  These two IDEs are basically equivalent except for the location of some
+configuration.  By integrating Black and Pylint, most everything important that
+can be done from a shell environment can also be done right in IntelliJ or PyCharm.
 
-Unfortunately, it is somewhat difficult to provide a working IntelliJ
-configuration that other developers can simply import. There are still some
-manual steps required.  I have checked in a minimal `.idea` directory, so at
-least all developers can share a single inspection profile, etc.
+Unfortunately, it is somewhat difficult to provide a working IntelliJ or
+PyCharm configuration that other developers can simply import. There are still
+some manual steps required.  I have checked in a minimal `.idea` directory, so
+at least all developers can share a single inspection profile, etc.
 
 ### Prerequisites
 
@@ -185,7 +197,7 @@ retained.)
 
 ### Plugins
 
-Install the following plugins:
+If you are using IntelliJ rather than PyCharm, install the following plugins:
 
 |Plugin|Description|
 |------|-----------|
@@ -199,6 +211,26 @@ Poetry:
 ```
 $ poetry run which python
 ```
+
+#### PyCharm
+
+Go to settings and find the `cedar-backup3` project.  Under **Python Interpreter**,
+select the Python virtualenv from above.
+
+Under **Project Structure**, mark both `src` and `tests` as source folders.  In the
+**Exclude Files** box, enter the following:
+
+```
+.coverage;.coveragerc;.github;.htmlcov;.idea;.isort.cfg;.pre-commit-config.yaml;.pylintrc;.pytest_cache;.readthedocs.yml;.tox;.toxrc;build;dist;docs/_build;out;poetry.lock;run
+```
+
+Finally, go to the gear icon in the project panel, and uncheck **Show Excluded
+Files**.  This will hide the files and directories that were excluded above.
+
+> _Note:_ On Windows, remember that Git Bash is is going to give you the translated
+> UNIX-like path.  Work backwards to find the real Windows path. 
+
+#### IntelliJ
 
 Right click on the `cedar-backup3` project in IntelliJ's project explorer and
 choose **Open Module Settings**.  
@@ -231,27 +263,32 @@ module configuration.
 
 ### Preferences
 
-API documentation is written using [Google Style Python Docstring](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).  However, this is not the default in IntelliJ.
+API documentation is written using [Google Style Python Docstring](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).  However, this is not the default in IntelliJ or PyCharm.
 
-Go to IntelliJ preferences, then select **Tools > Python Integrated Tools**.
-Under **Docstrings > Docstring format**, select _Google_. Click **OK**.
+In settings, go to **Tools > Python Integrated Tools**.  Under **Docstrings >
+Docstring format**, select _Google_. Click **OK**.
 
 ### Running Unit Tests
 
-Use **Build > Rebuild Project**, just to be sure that everything is up-to-date.
-Then, right click on the `tests` folder in IntelliJ's project explorer and
-choose **Run 'Unittests in tests'**.  Make sure that all of the tests pass.
+If you are using IntelliJ, first use **Build > Rebuild Project**, just to be
+sure that everything is up-to-date.
+
+In either IntelliJ or PyCharm, right click on the `tests` folder in the
+project explorer and choose **Run 'pytest in tests'**.  Make sure that all of
+the tests pass.
 
 ### External Tools
 
-Optionally, you might want to set up external tools in IntelliJ for some of
-common developer tasks: code reformatting and the PyLint checks.  One nice
-advantage of doing this is that you can configure an output filter, which makes
-the Pylint errors clickable in IntelliJ.  To set up external tools, go to
-IntelliJ preferences and find **Tools > External Tools**.  Add the tools as
-described below.
+Optionally, you might want to set up external tools in IntelliJ or PyCharm for
+some of common developer tasks: code reformatting and the PyLint and MyPy
+checks.  One nice advantage of doing this is that you can configure an output
+filter, which makes the Pylint and MyPy errors clickable in IntelliJ.  To set
+up external tools, go to IntelliJ or PyCharm settings and find **Tools >
+External Tools**.  Add the tools as described below. 
 
-#### Format Code
+#### Linux or MacOS
+
+##### Format Code
 
 |Field|Value|
 |-----|-----|
@@ -267,7 +304,7 @@ described below.
 |Make console active on message in stderr|_Unchecked_|
 |Output filters|_Empty_|
 
-#### Run Pylint Checks
+##### Run Pylint Checks
 
 |Field|Value|
 |-----|-----|
@@ -276,6 +313,44 @@ described below.
 |Group|`Developer Tools`|
 |Program|`$ProjectFileDir$/run`|
 |Arguments|`pylint`|
+|Working directory|`$ProjectFileDir$`|
+|Synchronize files after execution|_Unchecked_|
+|Open console for tool outout|_Checked_|
+|Make console active on message in stdout|_Checked_|
+|Make console active on message in stderr|_Checked_|
+|Output filters|`$FILE_PATH$:$LINE$:$COLUMN.*`|
+
+#### Windows
+
+On Windows, PyCharm and IntelliJ have problems invoking the `run` script,
+even via the Git Bash interpreter.  I have created a Powershell script
+`tools.ps1` that can be used instead.
+
+##### Format Code
+
+|Field|Value|
+|-----|-----|
+|Name|`Format Code`|
+|Description|`Run the Black and isort code formatters`|
+|Group|`Developer Tools`|
+|Program|`powershell.exe`|
+|Arguments|`-executionpolicy bypass -File tools.ps1 format`|
+|Working directory|`$ProjectFileDir$`|
+|Synchronize files after execution|_Checked_|
+|Open console for tool outout|_Checked_|
+|Make console active on message in stdout|_Unchecked_|
+|Make console active on message in stderr|_Unchecked_|
+|Output filters|_Empty_|
+
+##### Run Pylint Checks
+
+|Field|Value|
+|-----|-----|
+|Name|`Run Pylint Checks`|
+|Description|`Run the Pylint code checks`|
+|Group|`Developer Tools`|
+|Program|`powershell.exe`|
+|Arguments|`-executionpolicy bypass -File tools.ps1 pylint`|
 |Working directory|`$ProjectFileDir$`|
 |Synchronize files after execution|_Unchecked_|
 |Open console for tool outout|_Checked_|

--- a/run
+++ b/run
@@ -50,7 +50,7 @@ run_isort() {
       run_install
    fi
 
-   poetry run isort src/**/*.py tests/*.py
+   poetry run isort src/**/**/*.py tests/*.py
 
    echo "done"
 }

--- a/run
+++ b/run
@@ -288,6 +288,9 @@ case $1 in
       run_black
       run_isort
       ;;
+   diagnostics)
+      run_diagnostics
+      ;;
    unittest|test*)
       shift 1
       run_unittest $*

--- a/run
+++ b/run
@@ -3,7 +3,6 @@
 
 # Setup the virtual environment via Poetry and install pre-commit hooks
 run_install() {
-   poetry env use python3
    poetry install -v
    poetry run pre-commit install 
 }
@@ -20,6 +19,8 @@ run_requirements() {
 
 # Run the Pylint code checker
 run_pylint() {
+   echo "Running pylint checks..."
+
    poetry run which pylint > /dev/null
    if [ $? != 0 ]; then
       run_install
@@ -30,6 +31,8 @@ run_pylint() {
 
 # Run the black code formatter
 run_black() {
+   echo "Running black formatter..."
+
    poetry run which black > /dev/null
    if [ $? != 0 ]; then
       run_install
@@ -40,12 +43,16 @@ run_black() {
 
 # Run the isort import formatter
 run_isort() {
+   echo "Running isort formatter..."
+
    poetry run which isort > /dev/null
    if [ $? != 0 ]; then
       run_install
    fi
 
    poetry run isort src/**/*.py tests/*.py
+
+   echo "done"
 }
 
 # Print diagnostics about the Cedar Backup runtime environment

--- a/src/CedarBackup3/actions/__init__.py
+++ b/src/CedarBackup3/actions/__init__.py
@@ -43,14 +43,14 @@ Architecture Interface, i.e. the same interface that extensions implement.
 # Using 'from CedarBackup3.actions import *' will just import the modules listed
 # in the __all__ variable.
 
-import CedarBackup3.actions.constants
 import CedarBackup3.actions.collect
+import CedarBackup3.actions.constants
 import CedarBackup3.actions.initialize
+import CedarBackup3.actions.purge
+import CedarBackup3.actions.rebuild
 import CedarBackup3.actions.stage
 import CedarBackup3.actions.store
-import CedarBackup3.actions.purge
 import CedarBackup3.actions.util
-import CedarBackup3.actions.rebuild
 import CedarBackup3.actions.validate
 
 __all__ = ["constants", "collect", "initialize", "stage", "store", "purge", "util", "rebuild", "validate"]

--- a/src/CedarBackup3/actions/collect.py
+++ b/src/CedarBackup3/actions/collect.py
@@ -45,15 +45,14 @@ Implements the standard 'collect' action.
 # Imported modules
 ########################################################################
 
-import os
 import logging
+import os
 import pickle
 
-from CedarBackup3.filesystem import BackupFileList, FilesystemList
-from CedarBackup3.util import isStartOfWeek, changeOwnership, displayBytes, buildNormalizedPath
-from CedarBackup3.actions.constants import DIGEST_EXTENSION, COLLECT_INDICATOR
+from CedarBackup3.actions.constants import COLLECT_INDICATOR, DIGEST_EXTENSION
 from CedarBackup3.actions.util import writeIndicatorFile
-
+from CedarBackup3.filesystem import BackupFileList, FilesystemList
+from CedarBackup3.util import buildNormalizedPath, changeOwnership, displayBytes, isStartOfWeek
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/actions/initialize.py
+++ b/src/CedarBackup3/actions/initialize.py
@@ -49,7 +49,6 @@ import logging
 
 from CedarBackup3.actions.util import initializeMediaState
 
-
 ########################################################################
 # Module-wide constants and variables
 ########################################################################

--- a/src/CedarBackup3/actions/purge.py
+++ b/src/CedarBackup3/actions/purge.py
@@ -49,7 +49,6 @@ import logging
 
 from CedarBackup3.filesystem import PurgeItemList
 
-
 ########################################################################
 # Module-wide constants and variables
 ########################################################################

--- a/src/CedarBackup3/actions/rebuild.py
+++ b/src/CedarBackup3/actions/rebuild.py
@@ -45,18 +45,15 @@ Implements the standard 'rebuild' action.
 # Imported modules
 ########################################################################
 
-# System modules
-import sys
-import os
-import logging
 import datetime
+import logging
+import os
+import sys
 
-# Cedar Backup modules
-from CedarBackup3.util import deriveDayOfWeek
-from CedarBackup3.actions.util import checkMediaState
 from CedarBackup3.actions.constants import DIR_TIME_FORMAT, STAGE_INDICATOR
-from CedarBackup3.actions.store import writeImage, writeStoreIndicator, consistencyCheck
-
+from CedarBackup3.actions.store import consistencyCheck, writeImage, writeStoreIndicator
+from CedarBackup3.actions.util import checkMediaState
+from CedarBackup3.util import deriveDayOfWeek
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/actions/stage.py
+++ b/src/CedarBackup3/actions/stage.py
@@ -70,6 +70,7 @@ logger = logging.getLogger("CedarBackup3.log.actions.stage")
 ##########################
 
 # pylint: disable=W0613
+# noinspection PyTypeChecker
 def executeStage(configPath, options, config):
     """
    Executes the stage backup action.

--- a/src/CedarBackup3/actions/stage.py
+++ b/src/CedarBackup3/actions/stage.py
@@ -45,15 +45,14 @@ Implements the standard 'stage' action.
 # Imported modules
 ########################################################################
 
+import logging
 import os
 import time
-import logging
 
-from CedarBackup3.peer import RemotePeer, LocalPeer
-from CedarBackup3.util import getUidGid, changeOwnership, isStartOfWeek, isRunningAsRoot
 from CedarBackup3.actions.constants import DIR_TIME_FORMAT, STAGE_INDICATOR
 from CedarBackup3.actions.util import writeIndicatorFile
-
+from CedarBackup3.peer import LocalPeer, RemotePeer
+from CedarBackup3.util import changeOwnership, getUidGid, isRunningAsRoot, isStartOfWeek
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/actions/store.py
+++ b/src/CedarBackup3/actions/store.py
@@ -46,18 +46,16 @@ Implements the standard 'store' action.
 # Imported modules
 ########################################################################
 
-import sys
-import os
-import logging
 import datetime
+import logging
+import os
+import sys
 import tempfile
 
-from CedarBackup3.filesystem import compareContents
-from CedarBackup3.util import isStartOfWeek
-from CedarBackup3.util import mount, unmount, displayBytes
-from CedarBackup3.actions.util import createWriter, checkMediaState, buildMediaLabel, writeIndicatorFile
 from CedarBackup3.actions.constants import DIR_TIME_FORMAT, STAGE_INDICATOR, STORE_INDICATOR
-
+from CedarBackup3.actions.util import buildMediaLabel, checkMediaState, createWriter, writeIndicatorFile
+from CedarBackup3.filesystem import compareContents
+from CedarBackup3.util import displayBytes, isStartOfWeek, mount, unmount
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/actions/util.py
+++ b/src/CedarBackup3/actions/util.py
@@ -280,7 +280,7 @@ def initializeMediaState(config):
       ValueError: If media could not be initialized
       ValueError: If the configured media type is not rewritable
    """
-    if not config.store.mediaType in REWRITABLE_MEDIA_TYPES:
+    if config.store.mediaType not in REWRITABLE_MEDIA_TYPES:
         raise ValueError("Only rewritable media types can be initialized.")
     mediaLabel = buildMediaLabel()
     writer = createWriter(config)

--- a/src/CedarBackup3/actions/util.py
+++ b/src/CedarBackup3/actions/util.py
@@ -79,10 +79,6 @@ def findDailyDirs(stagingDir, indicatorFile):
     """
    Returns a list of all daily staging directories that do not contain
    the indicated indicator file.
-
-   Args:
-      stagingDir: Configured staging directory (config.targetDir)
-
    Returns:
        List of absolute paths to daily staging directories
    """

--- a/src/CedarBackup3/actions/util.py
+++ b/src/CedarBackup3/actions/util.py
@@ -45,22 +45,18 @@ Implements action-related utilities
 # Imported modules
 ########################################################################
 
-import os
-import time
-import tempfile
 import logging
+import os
+import tempfile
+import time
 
-from CedarBackup3.filesystem import FilesystemList
-from CedarBackup3.util import changeOwnership
-from CedarBackup3.util import deviceMounted
-from CedarBackup3.writers.util import readMediaLabel
-from CedarBackup3.writers.cdwriter import CdWriter
-from CedarBackup3.writers.dvdwriter import DvdWriter
-from CedarBackup3.writers.cdwriter import MEDIA_CDR_74, MEDIA_CDR_80, MEDIA_CDRW_74, MEDIA_CDRW_80
-from CedarBackup3.writers.dvdwriter import MEDIA_DVDPLUSR, MEDIA_DVDPLUSRW
-from CedarBackup3.config import DEFAULT_MEDIA_TYPE, DEFAULT_DEVICE_TYPE, REWRITABLE_MEDIA_TYPES
 from CedarBackup3.actions.constants import INDICATOR_PATTERN
-
+from CedarBackup3.config import DEFAULT_DEVICE_TYPE, DEFAULT_MEDIA_TYPE, REWRITABLE_MEDIA_TYPES
+from CedarBackup3.filesystem import FilesystemList
+from CedarBackup3.util import changeOwnership, deviceMounted
+from CedarBackup3.writers.cdwriter import MEDIA_CDR_74, MEDIA_CDR_80, MEDIA_CDRW_74, MEDIA_CDRW_80, CdWriter
+from CedarBackup3.writers.dvdwriter import MEDIA_DVDPLUSR, MEDIA_DVDPLUSRW, DvdWriter
+from CedarBackup3.writers.util import readMediaLabel
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/actions/validate.py
+++ b/src/CedarBackup3/actions/validate.py
@@ -45,12 +45,11 @@ Implements the standard 'validate' action.
 # Imported modules
 ########################################################################
 
-import os
 import logging
+import os
 
-from CedarBackup3.util import getUidGid, getFunctionReference
 from CedarBackup3.actions.util import createWriter
-
+from CedarBackup3.util import getFunctionReference, getUidGid
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/cli.py
+++ b/src/CedarBackup3/cli.py
@@ -648,11 +648,11 @@ class _ActionSet(object):
         if hooks is not None:
             for hook in hooks:
                 if hook.before:
-                    if not hook.action in preHookMap:
+                    if hook.action not in preHookMap:
                         preHookMap[hook.action] = []
                     preHookMap[hook.action].append(hook)
                 elif hook.after:
-                    if not hook.action in postHookMap:
+                    if hook.action not in postHookMap:
                         postHookMap[hook.action] = []
                     postHookMap[hook.action].append(hook)
         return (preHookMap, postHookMap)

--- a/src/CedarBackup3/cli.py
+++ b/src/CedarBackup3/cli.py
@@ -1188,7 +1188,8 @@ def _setupLogfile(options):
                 (uid, gid) = getUidGid(DEFAULT_OWNERSHIP[0], DEFAULT_OWNERSHIP[1])
             else:
                 (uid, gid) = getUidGid(options.owner[0], options.owner[1])
-            os.chown(logfile, uid, gid)
+            if sys.platform != "win32":
+                os.chown(logfile, uid, gid)  # pylint: disable=no-member
         except:
             pass
     return logfile

--- a/src/CedarBackup3/extend/amazons3.py
+++ b/src/CedarBackup3/extend/amazons3.py
@@ -83,24 +83,37 @@ if run on Windows.
 # Imported modules
 ########################################################################
 
-import sys
-import os
-import logging
-import tempfile
 import datetime
 import json
+import logging
+import os
 import shutil
+import sys
+import tempfile
 from functools import total_ordering
 
-from CedarBackup3.filesystem import FilesystemList, BackupFileList
-from CedarBackup3.util import resolveCommand, executeCommand, isRunningAsRoot, changeOwnership, isStartOfWeek
-from CedarBackup3.util import displayBytes, UNIT_BYTES
-from CedarBackup3.xmlutil import createInputDom, addContainerNode, addBooleanNode, addStringNode
-from CedarBackup3.xmlutil import readFirstChild, readString, readBoolean
-from CedarBackup3.actions.util import writeIndicatorFile
 from CedarBackup3.actions.constants import DIR_TIME_FORMAT, STAGE_INDICATOR
-from CedarBackup3.config import ByteQuantity, readByteQuantity, addByteQuantityNode
-
+from CedarBackup3.actions.util import writeIndicatorFile
+from CedarBackup3.config import ByteQuantity, addByteQuantityNode, readByteQuantity
+from CedarBackup3.filesystem import BackupFileList, FilesystemList
+from CedarBackup3.util import (
+    UNIT_BYTES,
+    changeOwnership,
+    displayBytes,
+    executeCommand,
+    isRunningAsRoot,
+    isStartOfWeek,
+    resolveCommand,
+)
+from CedarBackup3.xmlutil import (
+    addBooleanNode,
+    addContainerNode,
+    addStringNode,
+    createInputDom,
+    readBoolean,
+    readFirstChild,
+    readString,
+)
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/extend/amazons3.py
+++ b/src/CedarBackup3/extend/amazons3.py
@@ -858,7 +858,7 @@ def _verifyUpload(config, stagingDir, s3BucketUrl):
         if os.path.isfile(entry):
             key = entry.replace(stagingDir, "")
             size = int(os.stat(entry).st_size)
-            if not key in contents:
+            if key not in contents:
                 raise IOError("File was apparently not uploaded: [%s]" % entry)
             else:
                 if size != contents[key]:

--- a/src/CedarBackup3/extend/capacity.py
+++ b/src/CedarBackup3/extend/capacity.py
@@ -53,12 +53,10 @@ than X bytes of capacity remaining.
 import logging
 from functools import total_ordering
 
+from CedarBackup3.actions.util import checkMediaState, createWriter
+from CedarBackup3.config import ByteQuantity, addByteQuantityNode, readByteQuantity
 from CedarBackup3.util import displayBytes
-from CedarBackup3.config import ByteQuantity, readByteQuantity, addByteQuantityNode
-from CedarBackup3.xmlutil import createInputDom, addContainerNode, addStringNode
-from CedarBackup3.xmlutil import readFirstChild, readString
-from CedarBackup3.actions.util import createWriter, checkMediaState
-
+from CedarBackup3.xmlutil import addContainerNode, addStringNode, createInputDom, readFirstChild, readString
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/extend/encrypt.py
+++ b/src/CedarBackup3/extend/encrypt.py
@@ -56,15 +56,13 @@ configuration file.
 # Imported modules
 ########################################################################
 
-import os
 import logging
+import os
 from functools import total_ordering
 
-from CedarBackup3.util import resolveCommand, executeCommand, changeOwnership
-from CedarBackup3.xmlutil import createInputDom, addContainerNode, addStringNode
-from CedarBackup3.xmlutil import readFirstChild, readString
-from CedarBackup3.actions.util import findDailyDirs, writeIndicatorFile, getBackupFiles
-
+from CedarBackup3.actions.util import findDailyDirs, getBackupFiles, writeIndicatorFile
+from CedarBackup3.util import changeOwnership, executeCommand, resolveCommand
+from CedarBackup3.xmlutil import addContainerNode, addStringNode, createInputDom, readFirstChild, readString
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/extend/mbox.py
+++ b/src/CedarBackup3/extend/mbox.py
@@ -88,23 +88,38 @@ What is this extension?
 # Imported modules
 ########################################################################
 
-import os
-import logging
 import datetime
+import logging
+import os
 import pickle
 import tempfile
 from bz2 import BZ2File
-from gzip import GzipFile
 from functools import total_ordering
+from gzip import GzipFile
 
-from CedarBackup3.filesystem import FilesystemList, BackupFileList
-from CedarBackup3.xmlutil import createInputDom, addContainerNode, addStringNode
-from CedarBackup3.xmlutil import isElement, readChildren, readFirstChild, readString, readStringList
 from CedarBackup3.config import VALID_COLLECT_MODES, VALID_COMPRESS_MODES
-from CedarBackup3.util import isStartOfWeek, buildNormalizedPath
-from CedarBackup3.util import resolveCommand, executeCommand
-from CedarBackup3.util import ObjectTypeList, UnorderedList, RegexList, encodePath, changeOwnership
-
+from CedarBackup3.filesystem import BackupFileList, FilesystemList
+from CedarBackup3.util import (
+    ObjectTypeList,
+    RegexList,
+    UnorderedList,
+    buildNormalizedPath,
+    changeOwnership,
+    encodePath,
+    executeCommand,
+    isStartOfWeek,
+    resolveCommand,
+)
+from CedarBackup3.xmlutil import (
+    addContainerNode,
+    addStringNode,
+    createInputDom,
+    isElement,
+    readChildren,
+    readFirstChild,
+    readString,
+    readStringList,
+)
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/extend/mysql.py
+++ b/src/CedarBackup3/extend/mysql.py
@@ -85,18 +85,24 @@ mode ``0600``).
 # Imported modules
 ########################################################################
 
-import os
 import logging
-from gzip import GzipFile
+import os
 from bz2 import BZ2File
 from functools import total_ordering
+from gzip import GzipFile
 
-from CedarBackup3.xmlutil import createInputDom, addContainerNode, addStringNode, addBooleanNode
-from CedarBackup3.xmlutil import readFirstChild, readString, readStringList, readBoolean
 from CedarBackup3.config import VALID_COMPRESS_MODES
-from CedarBackup3.util import resolveCommand, executeCommand
-from CedarBackup3.util import ObjectTypeList, changeOwnership
-
+from CedarBackup3.util import ObjectTypeList, changeOwnership, executeCommand, resolveCommand
+from CedarBackup3.xmlutil import (
+    addBooleanNode,
+    addContainerNode,
+    addStringNode,
+    createInputDom,
+    readBoolean,
+    readFirstChild,
+    readString,
+    readStringList,
+)
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/extend/postgresql.py
+++ b/src/CedarBackup3/extend/postgresql.py
@@ -75,18 +75,24 @@ configuration.
 # Imported modules
 ########################################################################
 
-import os
 import logging
-from gzip import GzipFile
+import os
 from bz2 import BZ2File
 from functools import total_ordering
+from gzip import GzipFile
 
-from CedarBackup3.xmlutil import createInputDom, addContainerNode, addStringNode, addBooleanNode
-from CedarBackup3.xmlutil import readFirstChild, readString, readStringList, readBoolean
 from CedarBackup3.config import VALID_COMPRESS_MODES
-from CedarBackup3.util import resolveCommand, executeCommand
-from CedarBackup3.util import ObjectTypeList, changeOwnership
-
+from CedarBackup3.util import ObjectTypeList, changeOwnership, executeCommand, resolveCommand
+from CedarBackup3.xmlutil import (
+    addBooleanNode,
+    addContainerNode,
+    addStringNode,
+    createInputDom,
+    readBoolean,
+    readFirstChild,
+    readString,
+    readStringList,
+)
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/extend/split.py
+++ b/src/CedarBackup3/extend/split.py
@@ -57,17 +57,15 @@ configuration file.
 # Imported modules
 ########################################################################
 
+import logging
 import os
 import re
-import logging
 from functools import total_ordering
 
-from CedarBackup3.util import resolveCommand, executeCommand, changeOwnership
-from CedarBackup3.xmlutil import createInputDom, addContainerNode
-from CedarBackup3.xmlutil import readFirstChild
-from CedarBackup3.actions.util import findDailyDirs, writeIndicatorFile, getBackupFiles
-from CedarBackup3.config import ByteQuantity, readByteQuantity, addByteQuantityNode
-
+from CedarBackup3.actions.util import findDailyDirs, getBackupFiles, writeIndicatorFile
+from CedarBackup3.config import ByteQuantity, addByteQuantityNode, readByteQuantity
+from CedarBackup3.util import changeOwnership, executeCommand, resolveCommand
+from CedarBackup3.xmlutil import addContainerNode, createInputDom, readFirstChild
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/extend/subversion.py
+++ b/src/CedarBackup3/extend/subversion.py
@@ -69,22 +69,36 @@ Check the Subversion documentation for more information.
 # Imported modules
 ########################################################################
 
-import os
 import logging
+import os
 import pickle
 from bz2 import BZ2File
-from gzip import GzipFile
 from functools import total_ordering
+from gzip import GzipFile
 
-from CedarBackup3.xmlutil import createInputDom, addContainerNode, addStringNode
-from CedarBackup3.xmlutil import isElement, readChildren, readFirstChild, readString, readStringList
 from CedarBackup3.config import VALID_COLLECT_MODES, VALID_COMPRESS_MODES
 from CedarBackup3.filesystem import FilesystemList
-from CedarBackup3.util import UnorderedList, RegexList
-from CedarBackup3.util import isStartOfWeek, buildNormalizedPath
-from CedarBackup3.util import resolveCommand, executeCommand
-from CedarBackup3.util import ObjectTypeList, encodePath, changeOwnership
-
+from CedarBackup3.util import (
+    ObjectTypeList,
+    RegexList,
+    UnorderedList,
+    buildNormalizedPath,
+    changeOwnership,
+    encodePath,
+    executeCommand,
+    isStartOfWeek,
+    resolveCommand,
+)
+from CedarBackup3.xmlutil import (
+    addContainerNode,
+    addStringNode,
+    createInputDom,
+    isElement,
+    readChildren,
+    readFirstChild,
+    readString,
+    readStringList,
+)
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/extend/sysinfo.py
+++ b/src/CedarBackup3/extend/sysinfo.py
@@ -64,12 +64,11 @@ note will be logged at the INFO level.
 # Imported modules
 ########################################################################
 
-import os
 import logging
+import os
 from bz2 import BZ2File
 
-from CedarBackup3.util import resolveCommand, executeCommand, changeOwnership
-
+from CedarBackup3.util import changeOwnership, executeCommand, resolveCommand
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/peer.py
+++ b/src/CedarBackup3/peer.py
@@ -55,6 +55,7 @@ Attributes:
 
 import logging
 import os
+import sys
 import shutil
 
 from CedarBackup3.config import VALID_FAILURE_MODES
@@ -386,7 +387,8 @@ class LocalPeer(object):
                 logger.debug("Source [%s] is not a regular file.", sourceFile)
                 raise ValueError("Source is not a regular file.")
         if ownership is not None:
-            os.chown(targetFile, ownership[0], ownership[1])
+            if sys.platform != "win32":
+                os.chown(targetFile, ownership[0], ownership[1])  # pylint: disable=no-member
         if permissions is not None:
             os.chmod(targetFile, permissions)
 
@@ -1005,7 +1007,8 @@ class RemotePeer(object):
             raise IOError("Apparently did not copy any new files from remote peer.")
         for targetFile in differenceSet:
             if ownership is not None:
-                os.chown(targetFile, ownership[0], ownership[1])
+                if sys.platform != "win32":
+                    os.chown(targetFile, ownership[0], ownership[1])  # pylint: disable=no-member
             if permissions is not None:
                 os.chmod(targetFile, permissions)
         return len(differenceSet)
@@ -1084,7 +1087,8 @@ class RemotePeer(object):
         if not os.path.exists(targetFile):
             raise IOError("Apparently unable to copy file from remote host.")
         if ownership is not None:
-            os.chown(targetFile, ownership[0], ownership[1])
+            if sys.platform != "win32":
+                os.chown(targetFile, ownership[0], ownership[1])  # pylint: disable=no-member
         if permissions is not None:
             os.chmod(targetFile, permissions)
 

--- a/src/CedarBackup3/peer.py
+++ b/src/CedarBackup3/peer.py
@@ -55,8 +55,8 @@ Attributes:
 
 import logging
 import os
-import sys
 import shutil
+import sys
 
 from CedarBackup3.config import VALID_FAILURE_MODES
 from CedarBackup3.filesystem import FilesystemList

--- a/src/CedarBackup3/testutil.py
+++ b/src/CedarBackup3/testutil.py
@@ -497,7 +497,9 @@ def runningAsRoot():
     """
    Returns boolean indicating whether the effective user id is root.
    """
-    return os.geteuid() == 0
+    if sys.platform == "win32":
+        return False
+    return os.geteuid() == 0  # pylint: disable=no-member
 
 
 ##############################

--- a/src/CedarBackup3/testutil.py
+++ b/src/CedarBackup3/testutil.py
@@ -453,7 +453,7 @@ def _isPlatform(name):
       name: Platform name to check, currently one of "windows" or "macosx"
    """
     if name == "windows":
-        return platform.platform(True, True).startswith("Windows")
+        return sys.platform == "win32"
     elif name == "macosx":
         return sys.platform == "darwin"
     elif name == "debian":
@@ -488,6 +488,28 @@ def platformMacOsX():
     return _isPlatform("macosx")
 
 
+#############################
+# platformWindows() function
+#############################
+
+
+def platformWindows():
+    """
+   Returns boolean indicating whether this is the Windows platform.
+   """
+    return _isPlatform("windows")
+
+
+####################################
+# platformSupportsLinks() function
+####################################
+
+
+def platformSupportsLinks():
+    """Whether the platform supports soft links"""
+    return not platformWindows()
+
+
 ###########################
 # runningAsRoot() function
 ###########################
@@ -498,7 +520,8 @@ def runningAsRoot():
    Returns boolean indicating whether the effective user id is root.
    """
     if sys.platform == "win32":
-        return False
+        # we're sort of always root on Windows, at least for the purposes of this check
+        return True
     return os.geteuid() == 0  # pylint: disable=no-member
 
 

--- a/src/CedarBackup3/testutil.py
+++ b/src/CedarBackup3/testutil.py
@@ -336,8 +336,6 @@ def getLogin():
 def randomFilename(length, prefix=None, suffix=None):
     """
    Generates a random filename with the given length.
-   Args:
-      length: Length of filename
    @return Random filename
    """
     characters = [None] * length

--- a/src/CedarBackup3/testutil.py
+++ b/src/CedarBackup3/testutil.py
@@ -508,21 +508,6 @@ def platformSupportsLinks():
     return not platformWindows()
 
 
-###########################
-# runningAsRoot() function
-###########################
-
-
-def runningAsRoot():
-    """
-   Returns boolean indicating whether the effective user id is root.
-   """
-    if sys.platform == "win32":
-        # we're sort of always root on Windows, at least for the purposes of this check
-        return True
-    return os.geteuid() == 0  # pylint: disable=no-member
-
-
 ##############################
 # availableLocales() function
 ##############################

--- a/src/CedarBackup3/tools/__init__.py
+++ b/src/CedarBackup3/tools/__init__.py
@@ -44,7 +44,7 @@ the util/ directory.
 # Using 'from CedarBackup3.tools import *' will just import the modules listed
 # in the __all__ variable.
 
-import CedarBackup3.tools.span
 import CedarBackup3.tools.amazons3
+import CedarBackup3.tools.span
 
 __all__ = ["span", "amazons3"]

--- a/src/CedarBackup3/tools/amazons3.py
+++ b/src/CedarBackup3/tools/amazons3.py
@@ -1238,7 +1238,7 @@ def _verifyBucketContents(sourceDir, sourceFiles, s3BucketUrl):
         if os.path.isfile(entry):
             key = entry.replace(sourceDir, "")
             size = int(os.stat(entry).st_size)
-            if not key in contents:
+            if key not in contents:
                 logger.error("File was apparently not uploaded: [%s]", entry)
                 failed = True
             else:

--- a/src/CedarBackup3/tools/amazons3.py
+++ b/src/CedarBackup3/tools/amazons3.py
@@ -50,22 +50,21 @@ to get that.
 # Imported modules and constants
 ########################################################################
 
-import sys
-import os
-import logging
 import getopt
 import json
+import logging
+import os
+import sys
 import warnings
 from functools import total_ordering
 from pathlib import Path
+
 import chardet
 
-from CedarBackup3.release import AUTHOR, EMAIL, VERSION, DATE, COPYRIGHT
+from CedarBackup3.cli import DEFAULT_LOGFILE, DEFAULT_MODE, DEFAULT_OWNERSHIP, setupLogging
 from CedarBackup3.filesystem import FilesystemList
-from CedarBackup3.cli import setupLogging, DEFAULT_LOGFILE, DEFAULT_OWNERSHIP, DEFAULT_MODE
-from CedarBackup3.util import Diagnostics, splitCommandLine, encodePath
-from CedarBackup3.util import executeCommand
-
+from CedarBackup3.release import AUTHOR, COPYRIGHT, DATE, EMAIL, VERSION
+from CedarBackup3.util import Diagnostics, encodePath, executeCommand, splitCommandLine
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/tools/span.py
+++ b/src/CedarBackup3/tools/span.py
@@ -54,24 +54,27 @@ directly from the user.
 # Imported modules and constants
 ########################################################################
 
-import sys
-import os
 import logging
+import os
+import sys
 import tempfile
 
-from CedarBackup3.release import AUTHOR, EMAIL, VERSION, DATE, COPYRIGHT
-from CedarBackup3.util import displayBytes, convertSize, mount, unmount
-from CedarBackup3.util import UNIT_SECTORS, UNIT_BYTES
+from CedarBackup3.actions.constants import STORE_INDICATOR
+from CedarBackup3.actions.store import writeIndicatorFile
+from CedarBackup3.actions.util import createWriter, findDailyDirs
+from CedarBackup3.cli import (
+    DEFAULT_CONFIG,
+    DEFAULT_LOGFILE,
+    DEFAULT_MODE,
+    DEFAULT_OWNERSHIP,
+    Options,
+    setupLogging,
+    setupPathResolver,
+)
 from CedarBackup3.config import Config
 from CedarBackup3.filesystem import BackupFileList, compareDigestMaps, normalizeDir
-from CedarBackup3.cli import Options, setupLogging, setupPathResolver
-from CedarBackup3.cli import DEFAULT_CONFIG, DEFAULT_LOGFILE, DEFAULT_OWNERSHIP, DEFAULT_MODE
-from CedarBackup3.actions.constants import STORE_INDICATOR
-from CedarBackup3.actions.util import createWriter
-from CedarBackup3.actions.store import writeIndicatorFile
-from CedarBackup3.actions.util import findDailyDirs
-from CedarBackup3.util import Diagnostics
-
+from CedarBackup3.release import AUTHOR, COPYRIGHT, DATE, EMAIL, VERSION
+from CedarBackup3.util import UNIT_BYTES, UNIT_SECTORS, Diagnostics, convertSize, displayBytes, mount, unmount
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/util.py
+++ b/src/CedarBackup3/util.py
@@ -1089,7 +1089,7 @@ class Diagnostics(object):
                 sysname = "win32"
                 release = platform.platform()
                 machine = platform.machine()
-                return "%s (%s %s %s)" % (sys.platform, sysname, release, machine)
+                return "%s (%s %s)" % (sysname, release, machine)
             else:
                 uname = os.uname()  # pylint: disable=no-member
                 sysname = uname[0]  # i.e. Linux

--- a/src/CedarBackup3/util.py
+++ b/src/CedarBackup3/util.py
@@ -949,6 +949,7 @@ class Pipe(Popen):
    ``2>/dev/null`` construct.
    """
 
+    # noinspection PyArgumentList
     def __init__(self, cmd, bufsize=-1, ignoreStderr=False):
         stderr = STDOUT
         if ignoreStderr:
@@ -1933,10 +1934,10 @@ def buildNormalizedPath(path):
         return "-"
     else:
         normalized = path
-        normalized = re.sub(r"^\/", "", normalized)  # remove leading '/'
+        normalized = re.sub(r"^/", "", normalized)  # remove leading '/'
         normalized = re.sub(r"^\\", "", normalized)  # remove leading '\'
         normalized = re.sub(r"^\.", "_", normalized)  # convert leading '.' to '_' so file won't be hidden
-        normalized = re.sub(r"\/", "-", normalized)  # convert all '/' characters to '-'
+        normalized = re.sub(r"/", "-", normalized)  # convert all '/' characters to '-'
         normalized = re.sub(r"\\", "-", normalized)  # convert all '\' characters to '-'
         normalized = re.sub(r"\s", "_", normalized)  # convert all whitespace to '_'
         return normalized

--- a/src/CedarBackup3/writers/__init__.py
+++ b/src/CedarBackup3/writers/__init__.py
@@ -36,8 +36,8 @@ functionality, including utilities and specific writer implementations.
 # Using 'from CedarBackup3.writers import *' will just import the modules listed
 # in the __all__ variable.
 
-import CedarBackup3.writers.util
 import CedarBackup3.writers.cdwriter
 import CedarBackup3.writers.dvdwriter
+import CedarBackup3.writers.util
 
 __all__ = ["util", "cdwriter", "dvdwriter"]

--- a/src/CedarBackup3/writers/cdwriter.py
+++ b/src/CedarBackup3/writers/cdwriter.py
@@ -54,18 +54,24 @@ Attributes:
 # Imported modules
 ########################################################################
 
+import logging
 import os
 import re
-import logging
 import tempfile
 import time
 
-from CedarBackup3.util import resolveCommand, executeCommand
-from CedarBackup3.util import convertSize, displayBytes, encodePath
-from CedarBackup3.util import UNIT_SECTORS, UNIT_BYTES, UNIT_KBYTES, UNIT_MBYTES
-from CedarBackup3.writers.util import validateDevice, validateScsiId, validateDriveSpeed
-from CedarBackup3.writers.util import IsoImage
-
+from CedarBackup3.util import (
+    UNIT_BYTES,
+    UNIT_KBYTES,
+    UNIT_MBYTES,
+    UNIT_SECTORS,
+    convertSize,
+    displayBytes,
+    encodePath,
+    executeCommand,
+    resolveCommand,
+)
+from CedarBackup3.writers.util import IsoImage, validateDevice, validateDriveSpeed, validateScsiId
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/writers/dvdwriter.py
+++ b/src/CedarBackup3/writers/dvdwriter.py
@@ -53,18 +53,23 @@ Attributes:
 # Imported modules
 ########################################################################
 
+import logging
 import os
 import re
-import logging
 import tempfile
 import time
 
-from CedarBackup3.writers.util import IsoImage
-from CedarBackup3.util import resolveCommand, executeCommand
-from CedarBackup3.util import convertSize, displayBytes, encodePath
-from CedarBackup3.util import UNIT_SECTORS, UNIT_BYTES, UNIT_GBYTES
-from CedarBackup3.writers.util import validateDevice, validateDriveSpeed
-
+from CedarBackup3.util import (
+    UNIT_BYTES,
+    UNIT_GBYTES,
+    UNIT_SECTORS,
+    convertSize,
+    displayBytes,
+    encodePath,
+    executeCommand,
+    resolveCommand,
+)
+from CedarBackup3.writers.util import IsoImage, validateDevice, validateDriveSpeed
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/writers/util.py
+++ b/src/CedarBackup3/writers/util.py
@@ -45,13 +45,11 @@ Provides utilities related to image writers.
 # Imported modules
 ########################################################################
 
+import logging
 import os
 import re
-import logging
 
-from CedarBackup3.util import resolveCommand, executeCommand
-from CedarBackup3.util import convertSize, UNIT_BYTES, UNIT_SECTORS, encodePath
-
+from CedarBackup3.util import UNIT_BYTES, UNIT_SECTORS, convertSize, encodePath, executeCommand, resolveCommand
 
 ########################################################################
 # Module-wide constants and variables

--- a/src/CedarBackup3/writers/util.py
+++ b/src/CedarBackup3/writers/util.py
@@ -117,7 +117,7 @@ def validateScsiId(scsiId):
     if scsiId is not None:
         pattern = re.compile(r"^\s*(.*:)?\s*[0-9][0-9]*\s*,\s*[0-9][0-9]*\s*,\s*[0-9][0-9]*\s*$")
         if not pattern.search(scsiId):
-            pattern = re.compile(r"^\s*IO.*Services(\/[0-9][0-9]*)?\s*$")
+            pattern = re.compile(r"^\s*IO.*Services(/[0-9][0-9]*)?\s*$")
             if not pattern.search(scsiId):
                 raise ValueError("SCSI id is not in a valid form.")
     return scsiId

--- a/src/CedarBackup3/xmlutil.py
+++ b/src/CedarBackup3/xmlutil.py
@@ -88,8 +88,6 @@ VALID_BOOLEAN_VALUES = TRUE_BOOLEAN_VALUES + FALSE_BOOLEAN_VALUES
 def createInputDom(xmlData, name="cb_config"):
     """
    Creates a DOM tree based on reading an XML string.
-   Args:
-      name: Assumed base name of the document (root node name)
    Returns:
        Tuple (xmlDom, parentNode) for the parsed document
    Raises:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9747,7 +9747,6 @@ class TestActionSet(unittest.TestCase):
         dependencies = ActionDependencies(["collect",], [])
         extensions = ExtensionsConfig([ExtendedAction("one", "os.path", "isdir", dependencies=dependencies),], "dependency")
         options = OptionsConfig()
-        options = OptionsConfig()
         options.hooks = []
         actionSet = _ActionSet(actions, extensions, options, None, False, True)
         self.assertTrue(len(actionSet.actionSet) == 1)
@@ -9765,7 +9764,6 @@ class TestActionSet(unittest.TestCase):
         ]
         dependencies = ActionDependencies(["collect",], None)
         extensions = ExtensionsConfig([ExtendedAction("one", "os.path", "isdir", dependencies=dependencies),], "dependency")
-        options = OptionsConfig()
         options = OptionsConfig()
         options.hooks = [
             PreActionHook("store", "whatever"),
@@ -9787,7 +9785,6 @@ class TestActionSet(unittest.TestCase):
         dependencies = ActionDependencies(["collect",], [])
         extensions = ExtensionsConfig([ExtendedAction("one", "os.path", "isdir", dependencies=dependencies),], "dependency")
         options = OptionsConfig()
-        options = OptionsConfig()
         options.hooks = [
             PostActionHook("store", "whatever"),
         ]
@@ -9807,7 +9804,6 @@ class TestActionSet(unittest.TestCase):
         ]
         dependencies = ActionDependencies(["collect",], None)
         extensions = ExtensionsConfig([ExtendedAction("one", "os.path", "isdir", dependencies=dependencies),], "dependency")
-        options = OptionsConfig()
         options = OptionsConfig()
         options.hooks = [
             PreActionHook("one", "extension"),
@@ -9829,7 +9825,6 @@ class TestActionSet(unittest.TestCase):
         dependencies = ActionDependencies(["collect",], [])
         extensions = ExtensionsConfig([ExtendedAction("one", "os.path", "isdir", dependencies=dependencies),], "dependency")
         options = OptionsConfig()
-        options = OptionsConfig()
         options.hooks = [
             PostActionHook("one", "extension"),
         ]
@@ -9849,7 +9844,6 @@ class TestActionSet(unittest.TestCase):
         ]
         dependencies = ActionDependencies(["collect",], None)
         extensions = ExtensionsConfig([ExtendedAction("one", "os.path", "isdir", dependencies=dependencies),], "dependency")
-        options = OptionsConfig()
         options = OptionsConfig()
         options.hooks = [
             PostActionHook("one", "extension2"),
@@ -9873,7 +9867,6 @@ class TestActionSet(unittest.TestCase):
         dependencies = ActionDependencies(["collect",], [])
         extensions = ExtensionsConfig([ExtendedAction("one", "os.path", "isdir", dependencies=dependencies),], "dependency")
         options = OptionsConfig()
-        options = OptionsConfig()
         options.hooks = []
         actionSet = _ActionSet(actions, extensions, options, None, False, True)
         self.assertTrue(len(actionSet.actionSet) == 2)
@@ -9896,7 +9889,6 @@ class TestActionSet(unittest.TestCase):
         ]
         dependencies = ActionDependencies(["collect",], None)
         extensions = ExtensionsConfig([ExtendedAction("one", "os.path", "isdir", dependencies=dependencies),], "dependency")
-        options = OptionsConfig()
         options = OptionsConfig()
         options.hooks = [
             PreActionHook("purge", "rm -f"),
@@ -9923,7 +9915,6 @@ class TestActionSet(unittest.TestCase):
         dependencies = ActionDependencies(["collect",], [])
         extensions = ExtensionsConfig([ExtendedAction("one", "os.path", "isdir", dependencies=dependencies),], "dependency")
         options = OptionsConfig()
-        options = OptionsConfig()
         options.hooks = [
             PostActionHook("purge", "rm -f"),
         ]
@@ -9948,7 +9939,6 @@ class TestActionSet(unittest.TestCase):
         ]
         dependencies = ActionDependencies(["collect",], None)
         extensions = ExtensionsConfig([ExtendedAction("one", "os.path", "isdir", dependencies=dependencies),], "dependency")
-        options = OptionsConfig()
         options = OptionsConfig()
         options.hooks = [
             PreActionHook("collect", "something"),
@@ -9975,7 +9965,6 @@ class TestActionSet(unittest.TestCase):
         dependencies = ActionDependencies(["collect",], [])
         extensions = ExtensionsConfig([ExtendedAction("one", "os.path", "isdir", dependencies=dependencies),], "dependency")
         options = OptionsConfig()
-        options = OptionsConfig()
         options.hooks = [
             PostActionHook("collect", "something"),
         ]
@@ -10000,7 +9989,6 @@ class TestActionSet(unittest.TestCase):
         ]
         dependencies = ActionDependencies(["collect",], None)
         extensions = ExtensionsConfig([ExtendedAction("one", "os.path", "isdir", dependencies=dependencies),], "dependency")
-        options = OptionsConfig()
         options = OptionsConfig()
         options.hooks = [
             PreActionHook("one", "extension"),
@@ -10027,7 +10015,6 @@ class TestActionSet(unittest.TestCase):
         dependencies = ActionDependencies(["collect",], [])
         extensions = ExtensionsConfig([ExtendedAction("one", "os.path", "isdir", dependencies=dependencies),], "dependency")
         options = OptionsConfig()
-        options = OptionsConfig()
         options.hooks = [
             PostActionHook("one", "extension"),
         ]
@@ -10052,7 +10039,6 @@ class TestActionSet(unittest.TestCase):
         ]
         dependencies = ActionDependencies(["collect",], None)
         extensions = ExtensionsConfig([ExtendedAction("one", "os.path", "isdir", dependencies=dependencies),], "dependency")
-        options = OptionsConfig()
         options = OptionsConfig()
         options.hooks = [
             PostActionHook("one", "extension"),
@@ -10083,7 +10069,6 @@ class TestActionSet(unittest.TestCase):
         ]
         dependencies = ActionDependencies(["stage",], None)
         extensions = ExtensionsConfig([ExtendedAction("one", "os.path", "isdir", dependencies=dependencies),], "dependency")
-        options = OptionsConfig()
         options = OptionsConfig()
         options.hooks = [
             PostActionHook("one", "extension"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -170,6 +170,7 @@ RESOURCES = [
 ##########################
 
 
+# noinspection PyTypeChecker
 class TestByteQuantity(unittest.TestCase):
 
     """Tests for the ByteQuantity class."""

--- a/tests/test_dvdwriter.py
+++ b/tests/test_dvdwriter.py
@@ -199,6 +199,7 @@ class TestMediaCapacity(unittest.TestCase):
 ######################
 
 
+# noinspection PyListCreation
 class TestDvdWriter(unittest.TestCase):
 
     """Tests for the DvdWriter class."""

--- a/tests/test_dvdwriter.py
+++ b/tests/test_dvdwriter.py
@@ -199,7 +199,6 @@ class TestMediaCapacity(unittest.TestCase):
 ######################
 
 
-# noinspection PyListCreation
 class TestDvdWriter(unittest.TestCase):
 
     """Tests for the DvdWriter class."""

--- a/tests/test_encrypt.py
+++ b/tests/test_encrypt.py
@@ -633,7 +633,7 @@ class TestLocalConfig(unittest.TestCase):
 ######################
 
 
-@unittest.skipUnless(runAllTests(), "")
+@unittest.skipUnless(runAllTests(), "Limited test suite")
 class TestFunctions(unittest.TestCase):
 
     """Tests for the functions in encrypt.py."""

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -199,7 +199,6 @@ class TestFilesystemList(unittest.TestCase):
         components.insert(0, self.tmpdir)
         return buildPath(components)
 
-    # noinspection PyMethodMayBeStatic
     def pathPattern(self, path):
         """Returns properly-escaped regular expression pattern matching the indicated path."""
         return ".*%s.*" % path.replace("\\", "\\\\")
@@ -15889,7 +15888,6 @@ class TestBackupFileList(unittest.TestCase):
 ##########################
 
 
-# noinspection PyMethodMayBeStatic
 class TestPurgeItemList(unittest.TestCase):
 
     """Tests for the PurgeItemList class."""
@@ -15928,7 +15926,6 @@ class TestPurgeItemList(unittest.TestCase):
         components.insert(0, self.tmpdir)
         return buildPath(components)
 
-    # noinspection PyMethodMayBeStatic
     def pathPattern(self, path):
         """Returns properly-escaped regular expression pattern matching the indicated path."""
         return ".*%s.*" % path.replace("\\", "\\\\")

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -63,6 +63,10 @@ Test Notes
    really should split it up into smaller files, but I like having a 1:1
    relationship between a module and its test.
 
+   These tests do pass on Windows, but I've taken the easy way out.  In most cases,
+   rather than establising new expected results, I've excluded the tests that require
+   soft links or other UNIX-specific behaviors.
+
 Naming Conventions
 ==================
 
@@ -92,6 +96,7 @@ Full vs. Reduced Tests
 
 import hashlib
 import os
+import sys
 import tarfile
 import tempfile
 import unittest
@@ -105,6 +110,7 @@ from CedarBackup3.testutil import (
     failUnlessAssignRaises,
     findResources,
     platformMacOsX,
+    platformSupportsLinks,
     randomFilename,
     removedir,
 )
@@ -146,7 +152,6 @@ AGE_25_HOURS = 25 * 60 * 60  # in seconds
 AGE_47_HOURS = 47 * 60 * 60  # in seconds
 AGE_48_HOURS = 48 * 60 * 60  # in seconds
 AGE_49_HOURS = 49 * 60 * 60  # in seconds
-
 
 #######################################################################
 # Test Case Classes
@@ -720,6 +725,7 @@ class TestFilesystemList(unittest.TestCase):
         fsList.excludeLinks = True
         self.assertRaises(ValueError, fsList.addFile, path)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddFile_015(self):
         """
       Attempt to add a soft link; excludeLinks set.
@@ -1262,6 +1268,7 @@ class TestFilesystemList(unittest.TestCase):
         fsList.excludeLinks = True
         self.assertRaises(ValueError, fsList.addDir, path)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDir_015(self):
         """
       Attempt to add a soft link; excludeLinks set.
@@ -1934,12 +1941,13 @@ class TestFilesystemList(unittest.TestCase):
         fsList.excludeLinks = True
         self.assertRaises(ValueError, fsList.addDirContents, path)
 
-        path = self.buildPath(["tree5", "dir002", "link001"])  # link to a dir
-        fsList = FilesystemList()
-        fsList.excludeLinks = True
-        count = fsList.addDirContents(path)
-        self.assertEqual(0, count)
-        self.assertEqual([], fsList)
+        if platformSupportsLinks():
+            path = self.buildPath(["tree5", "dir002", "link001"])  # link to a dir
+            fsList = FilesystemList()
+            fsList.excludeLinks = True
+            count = fsList.addDirContents(path)
+            self.assertEqual(0, count)
+            self.assertEqual([], fsList)
 
     def testAddDirContents_026(self):
         """
@@ -1979,6 +1987,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertEqual(0, count)
         self.assertEqual([], fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_029(self):
         """
       Attempt to add an non-empty directory; excludeLinks set.
@@ -2688,6 +2697,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree6", "file002",]) in fsList)
         self.assertTrue(self.buildPath(["tree6", "link001",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_061(self):
         """
       Attempt to add a large tree, with excludeLinks set.
@@ -2938,6 +2948,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree6", "link001",]) in fsList)
         self.assertTrue(self.buildPath(["tree6", "link002",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_063(self):
         """
       Attempt to add a large tree, with excludePatterns set to exclude some entries.
@@ -3158,6 +3169,7 @@ class TestFilesystemList(unittest.TestCase):
         fsList = FilesystemList()
         self.assertRaises(ValueError, fsList.addDirContents, path)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_066(self):
         """
       Attempt to add a link to a directory (which should add its contents).
@@ -3896,6 +3908,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree6", "link001",]) in fsList)
         self.assertTrue(self.buildPath(["tree6", "link002",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_091(self):
         """
       Attempt to add a directory with linkDepth=1.
@@ -4072,6 +4085,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree6", "file002",]) in fsList)
         self.assertTrue(self.buildPath(["tree6", "link001",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_092(self):
         """
       Attempt to add a directory with linkDepth=2.
@@ -4347,6 +4361,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree22", "dir003", "link002",]) in fsList)
         self.assertTrue(self.buildPath(["tree22", "dir003", "link003",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_094(self):
         """
       Attempt to add a directory with linkDepth=1, dereference=False.
@@ -4374,6 +4389,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree22", "dir003", "link003", "link001",]) in fsList)
         self.assertTrue(self.buildPath(["tree22", "dir003", "link003", "link002",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_095(self):
         """
       Attempt to add a directory with linkDepth=2, dereference=False.
@@ -4405,6 +4421,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree22", "dir003", "link003", "link002", "link001",]) in fsList)
         self.assertTrue(self.buildPath(["tree22", "dir003", "link003", "link002", "link002",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_096(self):
         """
       Attempt to add a directory with linkDepth=3, dereference=False.
@@ -4459,6 +4476,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree22", "dir003", "link002",]) in fsList)
         self.assertTrue(self.buildPath(["tree22", "dir003", "link003",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_098(self):
         """
       Attempt to add a directory with linkDepth=1, dereference=True.
@@ -4490,6 +4508,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree22", "dir005", "link001",]) in fsList)
         self.assertTrue(self.buildPath(["tree22", "dir005", "link002",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_099(self):
         """
       Attempt to add a directory with linkDepth=2, dereference=True.
@@ -4533,6 +4552,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree22", "dir006", "link001",]) in fsList)
         self.assertTrue(self.buildPath(["tree22", "dir006", "link002",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_100(self):
         """
       Attempt to add a directory with linkDepth=3, dereference=True.
@@ -4615,6 +4635,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertEqual(0, count)
         self.assertEqual([], fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_103(self):
         """
       Attempt to add a soft link; excludeLinks and dereference set.
@@ -4680,6 +4701,7 @@ class TestFilesystemList(unittest.TestCase):
         fsList = FilesystemList()
         self.assertRaises(ValueError, fsList.addDirContents, path, True, True, 1, True)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_107(self):
         """
       Attempt to add a link to a directory (which should add its contents),
@@ -8815,6 +8837,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree4", "file006",]) in fsList)
         self.assertTrue(self.buildPath(["tree4", "file007",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveLinks_006(self):
         """
       Test with a non-empty list (files, directories and links) and a pattern of None.
@@ -9044,6 +9067,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree4", "file006",]) in fsList)
         self.assertTrue(self.buildPath(["tree4", "file007",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveLinks_008(self):
         """
       Test with a non-empty list (spaces in path names) and a pattern of None.
@@ -9860,6 +9884,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree4", "file006",]) in fsList)
         self.assertTrue(self.buildPath(["tree4", "file007",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveLinks_018(self):
         """
       Test with a non-empty list (files, directories and links) and a non-empty
@@ -10095,6 +10120,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree4", "file006",]) in fsList)
         self.assertTrue(self.buildPath(["tree4", "file007",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveLinks_020(self):
         """
       Test with a non-empty list (spaces in path names) and a non-empty pattern
@@ -10384,6 +10410,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree4", "file006",]) in fsList)
         self.assertTrue(self.buildPath(["tree4", "file007",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveLinks_024(self):
         """
       Test with a non-empty list (files, directories and links) and a non-empty
@@ -10614,6 +10641,7 @@ class TestFilesystemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree4", "file006",]) in fsList)
         self.assertTrue(self.buildPath(["tree4", "file007",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveLinks_026(self):
         """
       Test with a non-empty list (spaces in path names) and a non-empty pattern
@@ -13154,10 +13182,11 @@ class TestBackupFileList(unittest.TestCase):
         count = backupList.addDir(dirPath)
         self.assertEqual(0, count)
         self.assertEqual(0, len(backupList))
-        dirPath = self.buildPath(["tree5", "dir002", "link001",])
-        count = backupList.addDir(dirPath)
-        self.assertEqual(1, count)
-        self.assertEqual([dirPath], backupList)
+        if platformSupportsLinks():
+            dirPath = self.buildPath(["tree5", "dir002", "link001",])
+            count = backupList.addDir(dirPath)
+            self.assertEqual(1, count)
+            self.assertEqual([dirPath], backupList)
 
     def testAddDir_002(self):
         """
@@ -13174,11 +13203,12 @@ class TestBackupFileList(unittest.TestCase):
         count = backupList.addDir(dirPath)
         self.assertEqual(0, count)
         self.assertEqual(0, len(backupList))
-        dirPath = self.buildPath(["tree5", "dir002", "link001",])
-        dirPath = self.buildPath(["tree5", "dir002", "link001",])
-        count = backupList.addDir(dirPath)
-        self.assertEqual(1, count)
-        self.assertEqual([dirPath], backupList)
+        if platformSupportsLinks():
+            dirPath = self.buildPath(["tree5", "dir002", "link001",])
+            dirPath = self.buildPath(["tree5", "dir002", "link001",])
+            count = backupList.addDir(dirPath)
+            self.assertEqual(1, count)
+            self.assertEqual([dirPath], backupList)
 
     def testAddDir_003(self):
         """
@@ -13235,10 +13265,11 @@ class TestBackupFileList(unittest.TestCase):
         count = backupList.addDir(dirPath)
         self.assertEqual(0, count)
         self.assertEqual(0, len(backupList))
-        dirPath = self.buildPath(["tree5", "dir002", "link001",])
-        count = backupList.addDir(dirPath)
-        self.assertEqual(1, count)
-        self.assertEqual([dirPath], backupList)
+        if platformSupportsLinks():
+            dirPath = self.buildPath(["tree5", "dir002", "link001",])
+            count = backupList.addDir(dirPath)
+            self.assertEqual(1, count)
+            self.assertEqual([dirPath], backupList)
 
     def testAddDir_006(self):
         """
@@ -13255,10 +13286,11 @@ class TestBackupFileList(unittest.TestCase):
         count = backupList.addDir(dirPath)
         self.assertEqual(0, count)
         self.assertEqual(0, len(backupList))
-        dirPath = self.buildPath(["tree5", "dir002", "link001",])
-        count = backupList.addDir(dirPath)
-        self.assertEqual(1, count)
-        self.assertEqual([dirPath], backupList)
+        if platformSupportsLinks():
+            dirPath = self.buildPath(["tree5", "dir002", "link001",])
+            count = backupList.addDir(dirPath)
+            self.assertEqual(1, count)
+            self.assertEqual([dirPath], backupList)
 
     ###################
     # Test totalSize()
@@ -13272,6 +13304,7 @@ class TestBackupFileList(unittest.TestCase):
         size = backupList.totalSize()
         self.assertEqual(0, size)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testTotalSize_002(self):
         """
       Test on a non-empty list containing only valid entries.
@@ -13300,6 +13333,7 @@ class TestBackupFileList(unittest.TestCase):
         size = backupList.totalSize()
         self.assertEqual(1116, size)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testTotalSize_004(self):
         """
       Test on a non-empty list (some containing spaces).
@@ -13326,6 +13360,7 @@ class TestBackupFileList(unittest.TestCase):
         size = backupList.totalSize()
         self.assertEqual(1085, size)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testTotalSize_005(self):
         """
       Test on a non-empty list containing a directory (which shouldn't be
@@ -13358,6 +13393,7 @@ class TestBackupFileList(unittest.TestCase):
         size = backupList.totalSize()
         self.assertEqual(1116, size)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testTotalSize_006(self):
         """
       Test on a non-empty list containing a non-existent file.
@@ -13401,6 +13437,7 @@ class TestBackupFileList(unittest.TestCase):
         sizeMap = backupList.generateSizeMap()
         self.assertEqual(0, len(sizeMap))
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateSizeMap_002(self):
         """
       Test on a non-empty list containing only valid entries.
@@ -13444,6 +13481,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual(0, sizeMap[self.buildPath(["tree9", "link001",])])
         self.assertEqual(0, sizeMap[self.buildPath(["tree9", "link002",])])
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateSizeMap_004(self):
         """
       Test on a non-empty list (some containing spaces).
@@ -13483,6 +13521,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual(0, sizeMap[self.buildPath(["tree11", "dir with spaces", "link002",])])
         self.assertEqual(0, sizeMap[self.buildPath(["tree11", "dir with spaces", "link with spaces",])])
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateSizeMap_005(self):
         """
       Test on a non-empty list containing a directory (which shouldn't be
@@ -13530,6 +13569,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual(0, sizeMap[self.buildPath(["tree9", "link001",])])
         self.assertEqual(0, sizeMap[self.buildPath(["tree9", "link002",])])
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateSizeMap_006(self):
         """
       Test on a non-empty list containing a non-existent file.
@@ -13588,6 +13628,7 @@ class TestBackupFileList(unittest.TestCase):
         digestMap = backupList.generateDigestMap()
         self.assertEqual(0, len(digestMap))
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateDigestMap_002(self):
         """
       Test on a non-empty list containing only valid entries.
@@ -13622,6 +13663,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual("3ef0b16a6237af9200b7a46c1987d6a555973847", digestMap[self.buildPath(["tree9", "file001",])])
         self.assertEqual("fae89085ee97b57ccefa7e30346c573bb0a769db", digestMap[self.buildPath(["tree9", "file002",])])
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateDigestMap_003(self):
         """
       Test on a non-empty list containing only valid entries (some containing
@@ -13661,6 +13703,7 @@ class TestBackupFileList(unittest.TestCase):
             digestMap[self.buildPath(["tree11", "dir with spaces", "file with spaces",])],
         )
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateDigestMap_004(self):
         """
       Test on a non-empty list containing a directory (which shouldn't be
@@ -13699,6 +13742,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual("3ef0b16a6237af9200b7a46c1987d6a555973847", digestMap[self.buildPath(["tree9", "file001",])])
         self.assertEqual("fae89085ee97b57ccefa7e30346c573bb0a769db", digestMap[self.buildPath(["tree9", "file002",])])
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateDigestMap_005(self):
         """
       Test on a non-empty list containing a non-existent file.
@@ -13745,6 +13789,7 @@ class TestBackupFileList(unittest.TestCase):
         digestMap = backupList.generateDigestMap(stripPrefix=prefix)
         self.assertEqual(0, len(digestMap))
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateDigestMap_007(self):
         """
       Test on a non-empty list containing only valid entries, passing
@@ -13781,6 +13826,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual("3ef0b16a6237af9200b7a46c1987d6a555973847", digestMap[buildPath(["/", "file001",])])
         self.assertEqual("fae89085ee97b57ccefa7e30346c573bb0a769db", digestMap[buildPath(["/", "file002",])])
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateDigestMap_008(self):
         """
       Test on a non-empty list containing only valid entries (some containing
@@ -13818,6 +13864,7 @@ class TestBackupFileList(unittest.TestCase):
             "3ef0b16a6237af9200b7a46c1987d6a555973847", digestMap[buildPath(["/", "dir with spaces", "file with spaces",])]
         )
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateDigestMap_009(self):
         """
       Test on a non-empty list containing a directory (which shouldn't be
@@ -13857,6 +13904,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual("3ef0b16a6237af9200b7a46c1987d6a555973847", digestMap[buildPath(["/", "file001",])])
         self.assertEqual("fae89085ee97b57ccefa7e30346c573bb0a769db", digestMap[buildPath(["/", "file002",])])
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateDigestMap_010(self):
         """
       Test on a non-empty list containing a non-existent file, passing
@@ -13908,6 +13956,7 @@ class TestBackupFileList(unittest.TestCase):
         fittedList = backupList.generateFitted(2000)
         self.assertEqual(0, len(fittedList))
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateFitted_002(self):
         """
       Test on a non-empty list containing only valid entries, all of which fit.
@@ -13951,6 +14000,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree9", "link001",]) in fittedList)
         self.assertTrue(self.buildPath(["tree9", "link002",]) in fittedList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateFitted_003(self):
         """
       Test on a non-empty list containing only valid entries (some containing
@@ -13991,6 +14041,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree11", "dir with spaces", "link002",]) in fittedList)
         self.assertTrue(self.buildPath(["tree11", "dir with spaces", "link with spaces",]) in fittedList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateFitted_004(self):
         """
       Test on a non-empty list containing only valid entries, some of which
@@ -14037,6 +14088,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree9", "link001",]) in fittedList)
         self.assertTrue(self.buildPath(["tree9", "link002",]) in fittedList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateFitted_005(self):
         """
       Test on a non-empty list containing only valid entries, none of which
@@ -14077,6 +14129,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree9", "link001",]) in fittedList)
         self.assertTrue(self.buildPath(["tree9", "link002",]) in fittedList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateFitted_006(self):
         """
       Test on a non-empty list containing a directory (which shouldn't be
@@ -14124,6 +14177,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree9", "link001",]) in fittedList)
         self.assertTrue(self.buildPath(["tree9", "link002",]) in fittedList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateFitted_007(self):
         """
       Test on a non-empty list containing a non-existent file.
@@ -14182,6 +14236,7 @@ class TestBackupFileList(unittest.TestCase):
         spanSet = backupList.generateSpan(2000)
         self.assertEqual(0, len(spanSet))
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateSpan_002(self):
         """
       Test a set of files that all fit in one span item.
@@ -14230,6 +14285,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree9", "link001",]) in spanItem.fileList)
         self.assertTrue(self.buildPath(["tree9", "link002",]) in spanItem.fileList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateSpan_003(self):
         """
       Test a set of files that all fit in two span items.
@@ -14283,6 +14339,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree9", "dir002", "file002",]) in spanItem.fileList)
         self.assertTrue(self.buildPath(["tree9", "file001",]) in spanItem.fileList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateSpan_004(self):
         """
       Test a set of files that all fit in three span items.
@@ -14341,6 +14398,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual((134.0 / 515.0) * 100.0, spanItem.utilization)
         self.assertTrue(self.buildPath(["tree9", "dir002", "file001",]) in spanItem.fileList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateSpan_005(self):
         """
       Test a set of files where one of the files does not fit in the capacity.
@@ -14381,6 +14439,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertRaises(ValueError, backupList.generateTarfile, tarPath)
         self.assertTrue(not os.path.exists(tarPath))
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateTarfile_002(self):
         """
       Test on a non-empty list containing a directory (which shouldn't be
@@ -14437,6 +14496,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.tarPath(["tree9", "link001",]) in tarList)
         self.assertTrue(self.tarPath(["tree9", "link002",]) in tarList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateTarfile_003(self):
         """
       Test on a non-empty list containing a non-existent file, ignore=False.
@@ -14469,6 +14529,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertRaises(tarfile.TarError, backupList.generateTarfile, tarPath, ignore=False)
         self.assertTrue(not os.path.exists(tarPath))
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateTarfile_004(self):
         """
       Test on a non-empty list containing a non-existent file, ignore=True.
@@ -14519,6 +14580,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.tarPath(["tree9", "link001",]) in tarList)
         self.assertTrue(self.tarPath(["tree9", "link002",]) in tarList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateTarfile_005(self):
         """
       Test on a non-empty list containing only valid entries, with an invalid mode.
@@ -14548,6 +14610,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertRaises(ValueError, backupList.generateTarfile, tarPath, mode="bogus")
         self.assertTrue(not os.path.exists(tarPath))
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateTarfile_006(self):
         """
       Test on a non-empty list containing only valid entries, default mode.
@@ -14595,6 +14658,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.tarPath(["tree9", "link001",]) in tarList)
         self.assertTrue(self.tarPath(["tree9", "link002",]) in tarList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateTarfile_007(self):
         """
       Test on a non-empty list (some containing spaces), default mode.
@@ -14638,6 +14702,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.tarPath(["tree11", "dir with spaces", "link002",]) in tarList)
         self.assertTrue(self.tarPath(["tree11", "dir with spaces", "link with spaces",]) in tarList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateTarfile_008(self):
         """
       Test on a non-empty list containing only valid entries, 'tar' mode.
@@ -14685,6 +14750,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.tarPath(["tree9", "link001",]) in tarList)
         self.assertTrue(self.tarPath(["tree9", "link002",]) in tarList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateTarfile_009(self):
         """
       Test on a non-empty list containing only valid entries, 'targz' mode.
@@ -14732,6 +14798,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.tarPath(["tree9", "link001",]) in tarList)
         self.assertTrue(self.tarPath(["tree9", "link002",]) in tarList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateTarfile_010(self):
         """
       Test on a non-empty list containing only valid entries, 'tarbz2' mode.
@@ -14779,6 +14846,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.tarPath(["tree9", "link001",]) in tarList)
         self.assertTrue(self.tarPath(["tree9", "link002",]) in tarList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateTarfile_011(self):
         """
       Test on a non-empty list containing only valid entries, 'tar' mode, long target name.
@@ -14826,6 +14894,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.tarPath(["tree9", "link001",]) in tarList)
         self.assertTrue(self.tarPath(["tree9", "link002",]) in tarList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateTarfile_012(self):
         """
       Test on a non-empty list containing only valid entries, 'targz' mode, long target name.
@@ -14873,6 +14942,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.tarPath(["tree9", "link001",]) in tarList)
         self.assertTrue(self.tarPath(["tree9", "link002",]) in tarList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testGenerateTarfile_013(self):
         """
       Test on a non-empty list containing only valid entries, 'tarbz2' mode, long target name.
@@ -14985,6 +15055,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual(0, count)
         self.assertEqual(0, len(backupList))
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveUnchanged_003(self):
         """
       Test on an non-empty list with an empty digest map.
@@ -15031,6 +15102,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree9", "link001",]) in backupList)
         self.assertTrue(self.buildPath(["tree9", "link002",]) in backupList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveUnchanged_004(self):
         """
       Test with a digest map containing only entries that are not in the list.
@@ -15084,6 +15156,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree9", "link001",]) in backupList)
         self.assertTrue(self.buildPath(["tree9", "link002",]) in backupList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveUnchanged_005(self):
         """
       Test with a digest map containing only entries that are in the list, with
@@ -15138,6 +15211,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree9", "link001",]) in backupList)
         self.assertTrue(self.buildPath(["tree9", "link002",]) in backupList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveUnchanged_006(self):
         """
       Test with a digest map containing only entries that are in the list, with
@@ -15186,6 +15260,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree9", "link001",]) in backupList)
         self.assertTrue(self.buildPath(["tree9", "link002",]) in backupList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveUnchanged_007(self):
         """
       Test with a digest map containing both entries that are and are not in
@@ -15240,6 +15315,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree9", "link001",]) in backupList)
         self.assertTrue(self.buildPath(["tree9", "link002",]) in backupList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveUnchanged_008(self):
         """
       Test with a digest map containing both entries that are and are not in
@@ -15291,6 +15367,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree9", "link001",]) in backupList)
         self.assertTrue(self.buildPath(["tree9", "link002",]) in backupList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveUnchanged_009(self):
         """
       Test with a digest map containing both entries that are and are not in
@@ -15376,6 +15453,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual(0, len(backupList))
         self.assertEqual(0, len(newDigest))
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveUnchanged_012(self):
         """
       Test on an non-empty list with an empty digest map.
@@ -15429,6 +15507,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual("3ef0b16a6237af9200b7a46c1987d6a555973847", newDigest[self.buildPath(["tree9", "file001",])])
         self.assertEqual("fae89085ee97b57ccefa7e30346c573bb0a769db", newDigest[self.buildPath(["tree9", "file002",])])
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveUnchanged_013(self):
         """
       Test with a digest map containing only entries that are not in the list.
@@ -15489,6 +15568,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual("3ef0b16a6237af9200b7a46c1987d6a555973847", newDigest[self.buildPath(["tree9", "file001",])])
         self.assertEqual("fae89085ee97b57ccefa7e30346c573bb0a769db", newDigest[self.buildPath(["tree9", "file002",])])
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveUnchanged_014(self):
         """
       Test with a digest map containing only entries that are in the list, with
@@ -15550,6 +15630,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual("3ef0b16a6237af9200b7a46c1987d6a555973847", newDigest[self.buildPath(["tree9", "file001",])])
         self.assertEqual("fae89085ee97b57ccefa7e30346c573bb0a769db", newDigest[self.buildPath(["tree9", "file002",])])
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveUnchanged_015(self):
         """
       Test with a digest map containing only entries that are in the list, with
@@ -15605,6 +15686,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual("3ef0b16a6237af9200b7a46c1987d6a555973847", newDigest[self.buildPath(["tree9", "file001",])])
         self.assertEqual("fae89085ee97b57ccefa7e30346c573bb0a769db", newDigest[self.buildPath(["tree9", "file002",])])
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveUnchanged_016(self):
         """
       Test with a digest map containing both entries that are and are not in
@@ -15666,6 +15748,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual("3ef0b16a6237af9200b7a46c1987d6a555973847", newDigest[self.buildPath(["tree9", "file001",])])
         self.assertEqual("fae89085ee97b57ccefa7e30346c573bb0a769db", newDigest[self.buildPath(["tree9", "file002",])])
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveUnchanged_017(self):
         """
       Test with a digest map containing both entries that are and are not in
@@ -15724,6 +15807,7 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual("3ef0b16a6237af9200b7a46c1987d6a555973847", newDigest[self.buildPath(["tree9", "file001",])])
         self.assertEqual("fae89085ee97b57ccefa7e30346c573bb0a769db", newDigest[self.buildPath(["tree9", "file002",])])
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testRemoveUnchanged_018(self):
         """
       Test with a digest map containing both entries that are and are not in
@@ -16195,6 +16279,7 @@ class TestPurgeItemList(unittest.TestCase):
         self.assertEqual(0, count)
         self.assertEqual([], purgeList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_029(self):
         """
       Attempt to add an non-empty directory; excludeLinks set.
@@ -16899,6 +16984,7 @@ class TestPurgeItemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree6", "file002",]) in purgeList)
         self.assertTrue(self.buildPath(["tree6", "link001",]) in purgeList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_061(self):
         """
       Attempt to add a large tree, with excludeLinks set.
@@ -17147,6 +17233,7 @@ class TestPurgeItemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree6", "link001",]) in purgeList)
         self.assertTrue(self.buildPath(["tree6", "link002",]) in purgeList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_063(self):
         """
       Attempt to add a large tree, with excludePatterns set to exclude some entries.
@@ -17365,6 +17452,7 @@ class TestPurgeItemList(unittest.TestCase):
         purgeList = PurgeItemList()
         self.assertRaises(ValueError, purgeList.addDirContents, path)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_066(self):
         """
       Attempt to add a link to a directory (which should add its contents).
@@ -18007,6 +18095,7 @@ class TestPurgeItemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree6", "link001",]) in purgeList)
         self.assertTrue(self.buildPath(["tree6", "link002",]) in purgeList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_090(self):
         """
       Attempt to add a directory with linkDepth=1.
@@ -18182,6 +18271,7 @@ class TestPurgeItemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree6", "file002",]) in purgeList)
         self.assertTrue(self.buildPath(["tree6", "link001",]) in purgeList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_091(self):
         """
       Attempt to add a directory with linkDepth=2.
@@ -18455,6 +18545,7 @@ class TestPurgeItemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree22", "dir003", "link002",]) in purgeList)
         self.assertTrue(self.buildPath(["tree22", "dir003", "link003",]) in purgeList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_093(self):
         """
       Attempt to add a directory with linkDepth=1, dereference=False.
@@ -18481,6 +18572,7 @@ class TestPurgeItemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree22", "dir003", "link003", "link001",]) in purgeList)
         self.assertTrue(self.buildPath(["tree22", "dir003", "link003", "link002",]) in purgeList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_094(self):
         """
       Attempt to add a directory with linkDepth=2, dereference=False.
@@ -18511,6 +18603,7 @@ class TestPurgeItemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree22", "dir003", "link003", "link002", "link001",]) in purgeList)
         self.assertTrue(self.buildPath(["tree22", "dir003", "link003", "link002", "link002",]) in purgeList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_095(self):
         """
       Attempt to add a directory with linkDepth=3, dereference=False.
@@ -18563,6 +18656,7 @@ class TestPurgeItemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree22", "dir003", "link002",]) in purgeList)
         self.assertTrue(self.buildPath(["tree22", "dir003", "link003",]) in purgeList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_097(self):
         """
       Attempt to add a directory with linkDepth=1, dereference=True.
@@ -18593,6 +18687,7 @@ class TestPurgeItemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree22", "dir005", "link001",]) in purgeList)
         self.assertTrue(self.buildPath(["tree22", "dir005", "link002",]) in purgeList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_098(self):
         """
       Attempt to add a directory with linkDepth=2, dereference=True.
@@ -18635,6 +18730,7 @@ class TestPurgeItemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree22", "dir006", "link001",]) in purgeList)
         self.assertTrue(self.buildPath(["tree22", "dir006", "link002",]) in purgeList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddDirContents_099(self):
         """
       Attempt to add a directory with linkDepth=3, dereference=True.
@@ -19974,6 +20070,7 @@ class TestPurgeItemList(unittest.TestCase):
         self.assertRaises(ValueError, fsList.addDirContents, path)
         self.assertTrue(not os.path.exists(path))
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testPurgeItems_007(self):
         """
       Test with a list containing various kinds of entries, including links,
@@ -20076,6 +20173,7 @@ class TestPurgeItemList(unittest.TestCase):
         self.assertTrue(self.buildPath(["tree1", "file006",]) in fsList)
         self.assertTrue(self.buildPath(["tree1", "file007",]) in fsList)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testPurgeItems_009(self):
         """
       Test with a list containing entries containing spaces.

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -96,7 +96,6 @@ Full vs. Reduced Tests
 
 import hashlib
 import os
-import sys
 import tarfile
 import tempfile
 import unittest
@@ -200,6 +199,7 @@ class TestFilesystemList(unittest.TestCase):
         components.insert(0, self.tmpdir)
         return buildPath(components)
 
+    # noinspection PyMethodMayBeStatic
     def pathPattern(self, path):
         """Returns properly-escaped regular expression pattern matching the indicated path."""
         return ".*%s.*" % path.replace("\\", "\\\\")
@@ -13205,7 +13205,6 @@ class TestBackupFileList(unittest.TestCase):
         self.assertEqual(0, len(backupList))
         if platformSupportsLinks():
             dirPath = self.buildPath(["tree5", "dir002", "link001",])
-            dirPath = self.buildPath(["tree5", "dir002", "link001",])
             count = backupList.addDir(dirPath)
             self.assertEqual(1, count)
             self.assertEqual([dirPath], backupList)
@@ -15890,6 +15889,7 @@ class TestBackupFileList(unittest.TestCase):
 ##########################
 
 
+# noinspection PyMethodMayBeStatic
 class TestPurgeItemList(unittest.TestCase):
 
     """Tests for the PurgeItemList class."""
@@ -15928,6 +15928,7 @@ class TestPurgeItemList(unittest.TestCase):
         components.insert(0, self.tmpdir)
         return buildPath(components)
 
+    # noinspection PyMethodMayBeStatic
     def pathPattern(self, path):
         """Returns properly-escaped regular expression pattern matching the indicated path."""
         return ".*%s.*" % path.replace("\\", "\\\\")

--- a/tests/test_mbox.py
+++ b/tests/test_mbox.py
@@ -1492,7 +1492,6 @@ class TestMboxConfig(unittest.TestCase):
 ########################
 
 
-# noinspection PyListCreation
 class TestLocalConfig(unittest.TestCase):
 
     """Tests for the LocalConfig class."""

--- a/tests/test_mbox.py
+++ b/tests/test_mbox.py
@@ -1492,6 +1492,7 @@ class TestMboxConfig(unittest.TestCase):
 ########################
 
 
+# noinspection PyListCreation
 class TestLocalConfig(unittest.TestCase):
 
     """Tests for the LocalConfig class."""

--- a/tests/test_peer.py
+++ b/tests/test_peer.py
@@ -693,6 +693,7 @@ class TestLocalPeer(unittest.TestCase):
 ######################
 
 
+# noinspection PyDictCreation
 class TestRemotePeer(unittest.TestCase):
 
     """Tests for the RemotePeer class."""

--- a/tests/test_peer.py
+++ b/tests/test_peer.py
@@ -693,7 +693,6 @@ class TestLocalPeer(unittest.TestCase):
 ######################
 
 
-# noinspection PyDictCreation
 class TestRemotePeer(unittest.TestCase):
 
     """Tests for the RemotePeer class."""

--- a/tests/test_peer.py
+++ b/tests/test_peer.py
@@ -103,6 +103,7 @@ from CedarBackup3.testutil import (
     findResources,
     getLogin,
     getMaskAsMode,
+    platformWindows,
     removedir,
     runningAsRoot,
 )
@@ -357,6 +358,7 @@ class TestLocalPeer(unittest.TestCase):
         result = peer.checkCollectIndicator()
         self.assertEqual(True, result)
 
+    @unittest.skipIf(platformWindows(), "Behavior differs on Windows")
     def testCheckCollectIndicator_008(self):
         """
       Attempt to check collect indicator collect indicator file that does exist, custom name,
@@ -388,6 +390,7 @@ class TestLocalPeer(unittest.TestCase):
         peer = LocalPeer(name, collectDir)
         self.assertRaises(ValueError, peer.writeStageIndicator)
 
+    @unittest.skipIf(platformWindows(), "Behavior differs on Windows")
     def testWriteStageIndicator_002(self):
         """
       Attempt to write stage indicator with non-writable collect directory.
@@ -563,6 +566,7 @@ class TestLocalPeer(unittest.TestCase):
         stagedFiles = os.listdir(targetDir)
         self.assertEqual([], stagedFiles)
 
+    @unittest.skipIf(platformWindows(), "Behavior differs on Windows")
     def testStagePeer_007(self):
         """
       Attempt to stage files with empty collect directory, where the target
@@ -571,7 +575,7 @@ class TestLocalPeer(unittest.TestCase):
         self.extractTar("tree2")
         name = "peer1"
         collectDir = self.buildPath(["tree2", "dir001",])
-        targetDir = self.buildPath([" target directory ",])
+        targetDir = self.buildPath([" target directory ",])  # windows doesn't like paths that start or end with a space
         os.mkdir(targetDir)
         self.assertTrue(os.path.exists(collectDir))
         self.assertTrue(os.path.exists(targetDir))
@@ -646,6 +650,7 @@ class TestLocalPeer(unittest.TestCase):
         peer = LocalPeer(name, collectDir)
         self.assertRaises(ValueError, peer.stagePeer, targetDir=targetDir)
 
+    @unittest.skipIf(platformWindows(), "Behavior differs on Windows")
     def testStagePeer_011(self):
         """
       Attempt to stage files with non-empty collect directory and attempt to set valid permissions.
@@ -904,7 +909,7 @@ class TestRemotePeer(unittest.TestCase):
     # Test checkCollectIndicator()
     ###############################
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testCheckCollectIndicator_001(self):
         """
       Attempt to check collect indicator with invalid hostname.
@@ -919,7 +924,7 @@ class TestRemotePeer(unittest.TestCase):
         result = peer.checkCollectIndicator()
         self.assertEqual(False, result)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testCheckCollectIndicator_002(self):
         """
       Attempt to check collect indicator with invalid remote user.
@@ -934,7 +939,7 @@ class TestRemotePeer(unittest.TestCase):
         result = peer.checkCollectIndicator()
         self.assertEqual(False, result)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testCheckCollectIndicator_003(self):
         """
       Attempt to check collect indicator with invalid rcp command.
@@ -950,7 +955,7 @@ class TestRemotePeer(unittest.TestCase):
         result = peer.checkCollectIndicator()
         self.assertEqual(False, result)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testCheckCollectIndicator_004(self):
         """
       Attempt to check collect indicator with non-existent collect directory.
@@ -964,7 +969,7 @@ class TestRemotePeer(unittest.TestCase):
         result = peer.checkCollectIndicator()
         self.assertEqual(False, result)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testCheckCollectIndicator_005(self):
         """
       Attempt to check collect indicator with non-readable collect directory.
@@ -981,7 +986,7 @@ class TestRemotePeer(unittest.TestCase):
         self.assertEqual(False, result)
         os.chmod(collectDir, 0o777)  # so we can remove it safely
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testCheckCollectIndicator_006(self):
         """
       Attempt to check collect indicator collect indicator file that does not exist.
@@ -998,7 +1003,7 @@ class TestRemotePeer(unittest.TestCase):
         result = peer.checkCollectIndicator()
         self.assertEqual(False, result)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testCheckCollectIndicator_007(self):
         """
       Attempt to check collect indicator collect indicator file that does not exist, custom name.
@@ -1015,7 +1020,7 @@ class TestRemotePeer(unittest.TestCase):
         result = peer.checkCollectIndicator()
         self.assertEqual(False, result)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testCheckCollectIndicator_008(self):
         """
       Attempt to check collect indicator collect indicator file that does not
@@ -1033,7 +1038,7 @@ class TestRemotePeer(unittest.TestCase):
         result = peer.checkCollectIndicator()
         self.assertEqual(False, result)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testCheckCollectIndicator_009(self):
         """
       Attempt to check collect indicator collect indicator file that does not
@@ -1051,7 +1056,7 @@ class TestRemotePeer(unittest.TestCase):
         result = peer.checkCollectIndicator()
         self.assertEqual(False, result)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testCheckCollectIndicator_010(self):
         """
       Attempt to check collect indicator collect indicator file that does exist.
@@ -1070,7 +1075,7 @@ class TestRemotePeer(unittest.TestCase):
         result = peer.checkCollectIndicator()
         self.assertEqual(True, result)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testCheckCollectIndicator_011(self):
         """
       Attempt to check collect indicator collect indicator file that does exist, custom name.
@@ -1089,7 +1094,7 @@ class TestRemotePeer(unittest.TestCase):
         result = peer.checkCollectIndicator(collectIndicator="whatever")
         self.assertEqual(True, result)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testCheckCollectIndicator_012(self):
         """
       Attempt to check collect indicator collect indicator file that does exist,
@@ -1109,7 +1114,7 @@ class TestRemotePeer(unittest.TestCase):
         result = peer.checkCollectIndicator()
         self.assertEqual(True, result)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testCheckCollectIndicator_013(self):
         """
       Attempt to check collect indicator collect indicator file that does
@@ -1134,7 +1139,7 @@ class TestRemotePeer(unittest.TestCase):
     # Test writeStageIndicator()
     #############################
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteStageIndicator_001(self):
         """
       Attempt to write stage indicator with invalid hostname.
@@ -1148,7 +1153,7 @@ class TestRemotePeer(unittest.TestCase):
         peer = RemotePeer(name, collectDir, workingDir, remoteUser, rcpCommand=SAFE_RCP_COMMAND, rshCommand=SAFE_RSH_COMMAND)
         self.assertRaises((IOError, OSError), peer.writeStageIndicator)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteStageIndicator_002(self):
         """
       Attempt to write stage indicator with invalid remote user.
@@ -1162,7 +1167,7 @@ class TestRemotePeer(unittest.TestCase):
         peer = RemotePeer(name, collectDir, workingDir, remoteUser, rcpCommand=SAFE_RCP_COMMAND, rshCommand=SAFE_RSH_COMMAND)
         self.assertRaises((IOError, OSError), peer.writeStageIndicator)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteStageIndicator_003(self):
         """
       Attempt to write stage indicator with invalid rcp command.
@@ -1177,7 +1182,7 @@ class TestRemotePeer(unittest.TestCase):
         peer = RemotePeer(name, collectDir, workingDir, remoteUser, rcpCommand)
         self.assertRaises((IOError, OSError), peer.writeStageIndicator)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteStageIndicator_004(self):
         """
       Attempt to write stage indicator with non-existent collect directory.
@@ -1190,7 +1195,7 @@ class TestRemotePeer(unittest.TestCase):
         peer = RemotePeer(name, collectDir, workingDir, remoteUser)
         self.assertRaises(IOError, peer.writeStageIndicator)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteStageIndicator_005(self):
         """
       Attempt to write stage indicator with non-writable collect directory.
@@ -1209,7 +1214,7 @@ class TestRemotePeer(unittest.TestCase):
         self.assertTrue(not os.path.exists(stageIndicator))
         os.chmod(collectDir, 0o777)  # so we can remove it safely
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteStageIndicator_006(self):
         """
       Attempt to write stage indicator in a valid directory.
@@ -1226,7 +1231,7 @@ class TestRemotePeer(unittest.TestCase):
         peer.writeStageIndicator()
         self.assertTrue(os.path.exists(stageIndicator))
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteStageIndicator_007(self):
         """
       Attempt to write stage indicator in a valid directory, custom name.
@@ -1243,7 +1248,7 @@ class TestRemotePeer(unittest.TestCase):
         peer.writeStageIndicator(stageIndicator="newname")
         self.assertTrue(os.path.exists(stageIndicator))
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteStageIndicator_008(self):
         """
       Attempt to write stage indicator in a valid directory that contains
@@ -1261,7 +1266,7 @@ class TestRemotePeer(unittest.TestCase):
         peer.writeStageIndicator()
         self.assertTrue(os.path.exists(stageIndicator))
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteStageIndicator_009(self):
         """
       Attempt to write stage indicator in a valid directory, custom name, where
@@ -1283,7 +1288,7 @@ class TestRemotePeer(unittest.TestCase):
     # Test stagePeer()
     ###################
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testStagePeer_001(self):
         """
       Attempt to stage files with invalid hostname.
@@ -1300,7 +1305,7 @@ class TestRemotePeer(unittest.TestCase):
         peer = RemotePeer(name, collectDir, workingDir, remoteUser, rcpCommand=SAFE_RCP_COMMAND, rshCommand=SAFE_RSH_COMMAND)
         self.assertRaises((IOError, OSError), peer.stagePeer, targetDir=targetDir)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testStagePeer_002(self):
         """
       Attempt to stage files with invalid remote user.
@@ -1317,7 +1322,7 @@ class TestRemotePeer(unittest.TestCase):
         peer = RemotePeer(name, collectDir, workingDir, remoteUser, rcpCommand=SAFE_RCP_COMMAND, rshCommand=SAFE_RSH_COMMAND)
         self.assertRaises((IOError, OSError), peer.stagePeer, targetDir=targetDir)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testStagePeer_003(self):
         """
       Attempt to stage files with invalid rcp command.
@@ -1335,7 +1340,7 @@ class TestRemotePeer(unittest.TestCase):
         peer = RemotePeer(name, collectDir, workingDir, remoteUser, rcpCommand)
         self.assertRaises((IOError, OSError), peer.stagePeer, targetDir=targetDir)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testStagePeer_004(self):
         """
       Attempt to stage files with non-existent collect directory.
@@ -1351,7 +1356,7 @@ class TestRemotePeer(unittest.TestCase):
         peer = RemotePeer(name, collectDir, workingDir, remoteUser)
         self.assertRaises((IOError, OSError), peer.stagePeer, targetDir=targetDir)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testStagePeer_005(self):
         """
       Attempt to stage files with non-readable collect directory.
@@ -1370,7 +1375,7 @@ class TestRemotePeer(unittest.TestCase):
         self.assertRaises((IOError, OSError), peer.stagePeer, targetDir=targetDir)
         os.chmod(collectDir, 0o777)  # so we can remove it safely
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testStagePeer_006(self):
         """
       Attempt to stage files with non-absolute target directory.
@@ -1384,7 +1389,7 @@ class TestRemotePeer(unittest.TestCase):
         peer = RemotePeer(name, collectDir, workingDir, remoteUser)
         self.assertRaises(ValueError, peer.stagePeer, targetDir=targetDir)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testStagePeer_007(self):
         """
       Attempt to stage files with non-existent target directory.
@@ -1400,7 +1405,7 @@ class TestRemotePeer(unittest.TestCase):
         peer = RemotePeer(name, collectDir, workingDir, remoteUser)
         self.assertRaises(ValueError, peer.stagePeer, targetDir=targetDir)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testStagePeer_008(self):
         """
       Attempt to stage files with non-writable target directory.
@@ -1420,7 +1425,7 @@ class TestRemotePeer(unittest.TestCase):
         os.chmod(collectDir, 0o777)  # so we can remove it safely
         self.assertEqual(0, len(os.listdir(targetDir)))
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testStagePeer_009(self):
         """
       Attempt to stage files with empty collect directory.
@@ -1440,7 +1445,7 @@ class TestRemotePeer(unittest.TestCase):
         stagedFiles = os.listdir(targetDir)
         self.assertEqual([], stagedFiles)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testStagePeer_010(self):
         """
       Attempt to stage files with empty collect directory, with a target
@@ -1461,7 +1466,7 @@ class TestRemotePeer(unittest.TestCase):
         stagedFiles = os.listdir(targetDir)
         self.assertEqual([], stagedFiles)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testStagePeer_011(self):
         """
       Attempt to stage files with non-empty collect directory.
@@ -1489,7 +1494,7 @@ class TestRemotePeer(unittest.TestCase):
         self.assertTrue("file006" in stagedFiles)
         self.assertTrue("file007" in stagedFiles)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testStagePeer_012(self):
         """
       Attempt to stage files with non-empty collect directory, with a target
@@ -1518,7 +1523,7 @@ class TestRemotePeer(unittest.TestCase):
         self.assertTrue("file006" in stagedFiles)
         self.assertTrue("file007" in stagedFiles)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testStagePeer_013(self):
         """
       Attempt to stage files with non-empty collect directory containing links and directories.
@@ -1541,7 +1546,7 @@ class TestRemotePeer(unittest.TestCase):
         self.assertTrue("file001" in stagedFiles)
         self.assertTrue("file002" in stagedFiles)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testStagePeer_014(self):
         """
       Attempt to stage files with non-empty collect directory and attempt to set valid permissions.
@@ -1584,7 +1589,7 @@ class TestRemotePeer(unittest.TestCase):
     # Test executeRemoteCommand()
     ##############################
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testExecuteRemoteCommand(self):
         """
       Test that a simple remote command succeeds.
@@ -1602,14 +1607,14 @@ class TestRemotePeer(unittest.TestCase):
     # Test _buildCbackCommand()
     ############################
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testBuildCbackCommand_001(self):
         """
       Test with None for cbackCommand and action, False for fullBackup.
       """
         self.assertRaises(ValueError, RemotePeer._buildCbackCommand, None, None, False)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testBuildCbackCommand_002(self):
         """
       Test with None for cbackCommand, "collect" for action, False for fullBackup.
@@ -1617,7 +1622,7 @@ class TestRemotePeer(unittest.TestCase):
         result = RemotePeer._buildCbackCommand(None, "collect", False)
         self.assertEqual("/usr/bin/cback3 collect", result)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testBuildCbackCommand_003(self):
         """
       Test with "cback" for cbackCommand, "collect" for action, False for fullBackup.
@@ -1625,7 +1630,7 @@ class TestRemotePeer(unittest.TestCase):
         result = RemotePeer._buildCbackCommand("cback", "collect", False)
         self.assertEqual("cback collect", result)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testBuildCbackCommand_004(self):
         """
       Test with "cback" for cbackCommand, "collect" for action, True for fullBackup.

--- a/tests/test_peer.py
+++ b/tests/test_peer.py
@@ -105,8 +105,8 @@ from CedarBackup3.testutil import (
     getMaskAsMode,
     platformWindows,
     removedir,
-    runningAsRoot,
 )
+from CedarBackup3.util import isRunningAsRoot
 
 #######################################################################
 # Module-wide configuration and constants
@@ -405,6 +405,7 @@ class TestLocalPeer(unittest.TestCase):
             self.assertRaises((IOError, OSError), peer.writeStageIndicator)
             os.chmod(collectDir, 0o777)  # so we can remove it safely
 
+    @unittest.skipIf(platformWindows(), "Behavior differs on Windows")
     def testWriteStageIndicator_003(self):
         """
       Attempt to write stage indicator with non-writable collect directory, custom name.
@@ -531,6 +532,7 @@ class TestLocalPeer(unittest.TestCase):
         peer = LocalPeer(name, collectDir)
         self.assertRaises(ValueError, peer.stagePeer, targetDir=targetDir)
 
+    @unittest.skipIf(platformWindows(), "Behavior differs on Windows")
     def testStagePeer_005(self):
         """
       Attempt to stage files with non-writable target directory.

--- a/tests/test_peer.py
+++ b/tests/test_peer.py
@@ -395,7 +395,7 @@ class TestLocalPeer(unittest.TestCase):
         """
       Attempt to write stage indicator with non-writable collect directory.
       """
-        if not runningAsRoot():  # root doesn't get this error
+        if not isRunningAsRoot():  # root doesn't get this error
             name = "peer1"
             collectDir = self.buildPath(["collect",])
             os.mkdir(collectDir)
@@ -410,7 +410,7 @@ class TestLocalPeer(unittest.TestCase):
         """
       Attempt to write stage indicator with non-writable collect directory, custom name.
       """
-        if not runningAsRoot():  # root doesn't get this error
+        if not isRunningAsRoot():  # root doesn't get this error
             name = "peer1"
             collectDir = self.buildPath(["collect",])
             os.mkdir(collectDir)
@@ -537,7 +537,7 @@ class TestLocalPeer(unittest.TestCase):
         """
       Attempt to stage files with non-writable target directory.
       """
-        if not runningAsRoot():  # root doesn't get this error
+        if not isRunningAsRoot():  # root doesn't get this error
             self.extractTar("tree1")
             name = "peer1"
             collectDir = self.buildPath(["tree1"])

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -796,6 +796,7 @@ class TestFunctions(unittest.TestCase):
             self.assertTrue(os.path.exists(splitPath))
             self.assertEqual(leftoverBytes, os.stat(splitPath).st_size)
 
+    # noinspection PyMethodMayBeStatic
     def findBadLocale(self):
         """
       The split command localizes its output for certain locales.  This breaks

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -739,7 +739,7 @@ class TestLocalConfig(unittest.TestCase):
 ######################
 
 
-@unittest.skipUnless(runAllTests(), "")
+@unittest.skipUnless(runAllTests(), "Limited test suite")
 class TestFunctions(unittest.TestCase):
 
     """Tests for the functions in split.py."""

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -796,7 +796,6 @@ class TestFunctions(unittest.TestCase):
             self.assertTrue(os.path.exists(splitPath))
             self.assertEqual(leftoverBytes, os.stat(splitPath).st_size)
 
-    # noinspection PyMethodMayBeStatic
     def findBadLocale(self):
         """
       The split command localizes its output for certain locales.  This breaks

--- a/tests/test_subversion.py
+++ b/tests/test_subversion.py
@@ -1953,6 +1953,7 @@ class TestSubversionConfig(unittest.TestCase):
 ########################
 
 
+# noinspection PyListCreation
 class TestLocalConfig(unittest.TestCase):
 
     """Tests for the LocalConfig class."""

--- a/tests/test_subversion.py
+++ b/tests/test_subversion.py
@@ -1953,7 +1953,6 @@ class TestSubversionConfig(unittest.TestCase):
 ########################
 
 
-# noinspection PyListCreation
 class TestLocalConfig(unittest.TestCase):
 
     """Tests for the LocalConfig class."""

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2130,6 +2130,7 @@ class TestDiagnostics(unittest.TestCase):
         self.assertFalse(diagnostics.encoding is None)
         self.assertNotEqual("", diagnostics.encoding)
 
+    # noinspection PyStatementEffect
     def testMethods_005(self):
         """
       Test the locale attribute.
@@ -2186,6 +2187,7 @@ class TestDiagnostics(unittest.TestCase):
 ######################
 
 
+# noinspection PyUnusedLocal,PyShadowingBuiltins
 class TestFunctions(unittest.TestCase):
 
     """Tests for the various public functions."""
@@ -3754,7 +3756,6 @@ class TestFunctions(unittest.TestCase):
         """
       Test with simple string, a non-ascii path.
       """
-        encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
         path = "\xe2\x99\xaa\xe2\x99\xac"
         safePath = encodePath(path)
         self.assertTrue(isinstance(safePath, str))
@@ -4056,6 +4057,7 @@ class TestFunctions(unittest.TestCase):
     # Test isStartOfWeek()
     #######################
 
+    # noinspection PyUnboundLocalVariable
     def testIsStartOfWeek001(self):
         """
       Test positive case.
@@ -4077,6 +4079,7 @@ class TestFunctions(unittest.TestCase):
             result = isStartOfWeek("sunday")
         self.assertEqual(True, result)
 
+    # noinspection PyUnboundLocalVariable
     def testIsStartOfWeek002(self):
         """
       Test negative case.

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -81,7 +81,16 @@ import time
 import unittest
 from os.path import isdir
 
-from CedarBackup3.testutil import buildPath, captureOutput, configureLogging, extractTar, findResources, removedir
+from CedarBackup3.testutil import (
+    buildPath,
+    captureOutput,
+    configureLogging,
+    extractTar,
+    findResources,
+    platformSupportsLinks,
+    platformWindows,
+    removedir,
+)
 from CedarBackup3.util import (
     UNIT_BYTES,
     UNIT_GBYTES,
@@ -122,6 +131,17 @@ RESOURCES = [
     "lotsoflines.py",
     "tree10.tar.gz",
 ]
+
+# This is a command that is always valid on the platform, something other than the Python interpreter
+# The command must return a success status (zero) for the tests to pass
+if platformWindows():
+    VALID_COMMAND = [os.path.join(os.environ["SystemRoot"], "system32", "WindowsPowerShell", "v1.0", "powershell.exe")]
+    VALID_ARGS = ["Write-Output hello"]
+    VALID_OUTPUT = "hello\r\n"
+else:
+    VALID_COMMAND = ["echo"]
+    VALID_ARGS = ["hello"]
+    VALID_OUTPUT = "hello\n"
 
 
 #######################################################################
@@ -2402,12 +2422,10 @@ class TestFunctions(unittest.TestCase):
     def testExecuteCommand_001(self):
         """
       Execute a command that should succeed, no arguments, returnOutput=False
-      Command-line: echo
+      Command-line: non-Python platform-specific valid command
       """
-        command = [
-            "echo",
-        ]
-        args = []
+        command = VALID_COMMAND
+        args = VALID_ARGS
         (result, output) = executeCommand(command, args, returnOutput=False)
         self.assertEqual(0, result)
         self.assertEqual(None, output)
@@ -2515,16 +2533,14 @@ class TestFunctions(unittest.TestCase):
     def testExecuteCommand_008(self):
         """
       Execute a command that should succeed, no arguments, returnOutput=True
-      Command-line: echo
+      Command-line: non-Python platform-specific valid command
       """
-        command = [
-            "echo",
-        ]
-        args = []
+        command = VALID_COMMAND
+        args = VALID_ARGS
         (result, output) = executeCommand(command, args, returnOutput=True)
         self.assertEqual(0, result)
         self.assertEqual(1, len(output))
-        self.assertEqual(os.linesep, output[0])
+        self.assertEqual(VALID_OUTPUT, output[0])
 
     def testExecuteCommand_009(self):
         """
@@ -2638,12 +2654,10 @@ class TestFunctions(unittest.TestCase):
         """
       Execute a command that should succeed, no arguments, returnOutput=False
       Do this all bundled into the command list, just to check that this works as expected.
-      Command-line: echo
+      Command-line: non-Python platform-specific valid command
       """
-        command = [
-            "echo",
-        ]
-        args = []
+        command = VALID_COMMAND
+        args = VALID_ARGS
         (result, output) = executeCommand(command, args, returnOutput=False)
         self.assertEqual(0, result)
         self.assertEqual(None, output)
@@ -2752,16 +2766,14 @@ class TestFunctions(unittest.TestCase):
         """
       Execute a command that should succeed, no arguments, returnOutput=True
       Do this all bundled into the command list, just to check that this works as expected.
-      Command-line: echo
+      Command-line: non-Python platform-specific valid command
       """
-        command = [
-            "echo",
-        ]
-        args = []
+        command = VALID_COMMAND
+        args = VALID_ARGS
         (result, output) = executeCommand(command, args, returnOutput=True)
         self.assertEqual(0, result)
         self.assertEqual(1, len(output))
-        self.assertEqual(os.linesep, output[0])
+        self.assertEqual(VALID_OUTPUT, output[0])
 
     def testExecuteCommand_023(self):
         """
@@ -2871,12 +2883,10 @@ class TestFunctions(unittest.TestCase):
     def testExecuteCommand_030(self):
         """
       Execute a command that should succeed, no arguments, returnOutput=False, ignoring stderr.
-      Command-line: echo
+      Command-line: non-Python platform-specific valid command
       """
-        command = [
-            "echo",
-        ]
-        args = []
+        command = VALID_COMMAND
+        args = VALID_ARGS
         (result, output) = executeCommand(command, args, returnOutput=False, ignoreStderr=True)
         self.assertEqual(0, result)
         self.assertEqual(None, output)
@@ -2984,16 +2994,14 @@ class TestFunctions(unittest.TestCase):
     def testExecuteCommand_037(self):
         """
       Execute a command that should succeed, no arguments, returnOutput=True, ignoring stderr.
-      Command-line: echo
+      Command-line: non-Python platform-specific valid command
       """
-        command = [
-            "echo",
-        ]
-        args = []
+        command = VALID_COMMAND
+        args = VALID_ARGS
         (result, output) = executeCommand(command, args, returnOutput=True, ignoreStderr=True)
         self.assertEqual(0, result)
         self.assertEqual(1, len(output))
-        self.assertEqual(os.linesep, output[0])
+        self.assertEqual(VALID_OUTPUT, output[0])
 
     def testExecuteCommand_038(self):
         """
@@ -3111,12 +3119,10 @@ class TestFunctions(unittest.TestCase):
         """
       Execute a command that should succeed, no arguments, returnOutput=False, ignoring stderr.
       Do this all bundled into the command list, just to check that this works as expected.
-      Command-line: echo
+      Command-line: non-Python platform-specific valid command
       """
-        command = [
-            "echo",
-        ]
-        args = []
+        command = VALID_COMMAND
+        args = VALID_ARGS
         (result, output) = executeCommand(command, args, returnOutput=False, ignoreStderr=True)
         self.assertEqual(0, result)
         self.assertEqual(None, output)
@@ -3225,16 +3231,14 @@ class TestFunctions(unittest.TestCase):
         """
       Execute a command that should succeed, no arguments, returnOutput=True, ignoring stderr.
       Do this all bundled into the command list, just to check that this works as expected.
-      Command-line: echo
+      Command-line: non-Python platform-specific valid command
       """
-        command = [
-            "echo",
-        ]
-        args = []
+        command = VALID_COMMAND
+        args = VALID_ARGS
         (result, output) = executeCommand(command, args, returnOutput=True, ignoreStderr=True)
         self.assertEqual(0, result)
         self.assertEqual(1, len(output))
-        self.assertEqual(os.linesep, output[0])
+        self.assertEqual(VALID_OUTPUT, output[0])
 
     def testExecuteCommand_052(self):
         """
@@ -3352,12 +3356,10 @@ class TestFunctions(unittest.TestCase):
         """
       Execute a command that should succeed, no arguments, returnOutput=False, using outputFile.
       Do this all bundled into the command list, just to check that this works as expected.
-      Command-line: echo
+      Command-line: non-Python platform-specific valid command
       """
-        command = [
-            "echo",
-        ]
-        args = []
+        command = VALID_COMMAND
+        args = VALID_ARGS
 
         filename = self.getTempfile()
         with open(filename, "wb") as outputFile:
@@ -3368,7 +3370,9 @@ class TestFunctions(unittest.TestCase):
             output = f.readlines()
 
         self.assertEqual(1, len(output))
-        self.assertEqual(os.linesep, output[0])
+        self.assertEqual(
+            VALID_OUTPUT, output[0].replace("\n", os.linesep)
+        )  # when reading from a file, Python translates the line ending
 
     def testExecuteCommand_059(self):
         """
@@ -3412,7 +3416,7 @@ class TestFunctions(unittest.TestCase):
             output = f.readlines()
 
         self.assertEqual(1, len(output))
-        self.assertEqual(os.linesep, output[0])
+        self.assertEqual("\n", output[0])
 
     def testExecuteCommand_061(self):
         """
@@ -3437,7 +3441,7 @@ class TestFunctions(unittest.TestCase):
             output = f.readlines()
 
         self.assertEqual(1, len(output))
-        self.assertEqual("first%s" % os.linesep, output[0])
+        self.assertEqual("first\n", output[0])
 
     def testExecuteCommand_062(self):
         """
@@ -3463,8 +3467,8 @@ class TestFunctions(unittest.TestCase):
             output = f.readlines()
 
         self.assertEqual(2, len(output))
-        self.assertEqual("first%s" % os.linesep, output[0])
-        self.assertEqual("second%s" % os.linesep, output[1])
+        self.assertEqual("first\n", output[0])
+        self.assertEqual("second\n", output[1])
 
     def testExecuteCommand_063(self):
         """
@@ -3488,7 +3492,7 @@ class TestFunctions(unittest.TestCase):
             output = f.readlines()
 
         self.assertEqual(1, len(output))
-        self.assertEqual(os.linesep, output[0])
+        self.assertEqual("\n", output[0])
 
     def testExecuteCommand_064(self):
         """
@@ -3514,8 +3518,8 @@ class TestFunctions(unittest.TestCase):
             output = f.readlines()
 
         self.assertEqual(2, len(output))
-        self.assertEqual("first%s" % os.linesep, output[0])
-        self.assertEqual("second%s" % os.linesep, output[1])
+        self.assertEqual("first\n", output[0])
+        self.assertEqual("second\n", output[1])
 
     def testExecuteCommand_065(self):
         """
@@ -3893,7 +3897,10 @@ class TestFunctions(unittest.TestCase):
       Test that the function behaves sensibly.
       """
         device = nullDevice()
-        self.assertEqual("/dev/null", device)
+        if sys.platform == "win32":
+            self.assertEqual("nul", device)
+        else:
+            self.assertEqual("/dev/null", device)
 
     ######################
     # Test displayBytes()
@@ -4292,6 +4299,7 @@ class TestFunctions(unittest.TestCase):
     # Test dereferenceLink()
     #########################
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testDereferenceLink_001(self):
         """
       Test for a path that is a link, absolute=false.
@@ -4302,6 +4310,7 @@ class TestFunctions(unittest.TestCase):
         actual = dereferenceLink(path, absolute=False)
         self.assertEqual(expected, actual)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testDereferenceLink_002(self):
         """
       Test for a path that is a link, absolute=true.

--- a/tests/test_writers_util.py
+++ b/tests/test_writers_util.py
@@ -339,7 +339,6 @@ class TestFunctions(unittest.TestCase):
 #####################
 
 
-# noinspection PyDictCreation
 class TestIsoImage(unittest.TestCase):
 
     """Tests for the IsoImage class."""

--- a/tests/test_writers_util.py
+++ b/tests/test_writers_util.py
@@ -91,7 +91,6 @@ Full vs. Reduced Tests
 ########################################################################
 
 import os
-import sys
 import tempfile
 import time
 import unittest
@@ -340,6 +339,7 @@ class TestFunctions(unittest.TestCase):
 #####################
 
 
+# noinspection PyDictCreation
 class TestIsoImage(unittest.TestCase):
 
     """Tests for the IsoImage class."""

--- a/tests/test_writers_util.py
+++ b/tests/test_writers_util.py
@@ -91,12 +91,22 @@ Full vs. Reduced Tests
 ########################################################################
 
 import os
+import sys
 import tempfile
 import time
 import unittest
 
 from CedarBackup3.filesystem import FilesystemList
-from CedarBackup3.testutil import buildPath, configureLogging, extractTar, findResources, platformMacOsX, removedir, setupOverrides
+from CedarBackup3.testutil import (
+    buildPath,
+    configureLogging,
+    extractTar,
+    findResources,
+    platformMacOsX,
+    platformSupportsLinks,
+    removedir,
+    setupOverrides,
+)
 from CedarBackup3.util import executeCommand
 from CedarBackup3.writers.util import IsoImage, validateDriveSpeed, validateScsiId
 
@@ -889,6 +899,7 @@ class TestIsoImage(unittest.TestCase):
         isoImage = IsoImage()
         self.assertRaises(ValueError, isoImage.addEntry, file1)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddEntry_002(self):
         """
       Attempt to add a an entry that is a soft link to a file.
@@ -898,6 +909,7 @@ class TestIsoImage(unittest.TestCase):
         isoImage = IsoImage()
         self.assertRaises(ValueError, isoImage.addEntry, file1)
 
+    @unittest.skipUnless(platformSupportsLinks(), "Requires soft links")
     def testAddEntry_003(self):
         """
       Attempt to add a an entry that is a soft link to a directory
@@ -1172,7 +1184,7 @@ class TestIsoImage(unittest.TestCase):
     # Test getEstimatedSize()
     ##########################
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testGetEstimatedSize_001(self):
         """
       Test with an empty list.
@@ -1181,7 +1193,7 @@ class TestIsoImage(unittest.TestCase):
         isoImage = IsoImage()
         self.assertRaises(ValueError, isoImage.getEstimatedSize)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testGetEstimatedSize_002(self):
         """
       Test with non-empty empty list.
@@ -1197,7 +1209,7 @@ class TestIsoImage(unittest.TestCase):
     # Test writeImage()
     ####################
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_001(self):
         """
       Attempt to write an image containing no entries.
@@ -1206,7 +1218,7 @@ class TestIsoImage(unittest.TestCase):
         imagePath = self.buildPath(["image.iso",])
         self.assertRaises(ValueError, isoImage.writeImage, imagePath)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_002(self):
         """
       Attempt to write an image containing only an empty directory, no graft point.
@@ -1224,7 +1236,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(mountPath in fsList)
         self.assertTrue(os.path.join(mountPath, "dir002") in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_003(self):
         """
       Attempt to write an image containing only an empty directory, with a graft point.
@@ -1243,7 +1255,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(os.path.join(mountPath, "base") in fsList)
         self.assertTrue(os.path.join(mountPath, "base", "dir002") in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_004(self):
         """
       Attempt to write an image containing only a non-empty directory, no graft
@@ -1270,7 +1282,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(os.path.join(mountPath, "dir002", "dir001",) in fsList)
         self.assertTrue(os.path.join(mountPath, "dir002", "dir002",) in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_005(self):
         """
       Attempt to write an image containing only a non-empty directory, with a
@@ -1299,7 +1311,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(os.path.join(mountPath, "something", "else", "dir002", "dir001",) in fsList)
         self.assertTrue(os.path.join(mountPath, "something", "else", "dir002", "dir002",) in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_006(self):
         """
       Attempt to write an image containing only a file, no graft point.
@@ -1317,7 +1329,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(mountPath in fsList)
         self.assertTrue(os.path.join(mountPath, "file001",) in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_007(self):
         """
       Attempt to write an image containing only a file, with a graft point.
@@ -1336,7 +1348,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(os.path.join(mountPath, "point",) in fsList)
         self.assertTrue(os.path.join(mountPath, "point", "file001",) in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_008(self):
         """
       Attempt to write an image containing a file and an empty directory, no
@@ -1358,7 +1370,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(os.path.join(mountPath, "file001",) in fsList)
         self.assertTrue(os.path.join(mountPath, "dir002",) in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_009(self):
         """
       Attempt to write an image containing a file and an empty directory, with
@@ -1382,7 +1394,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(os.path.join(mountPath, "other", "file001",) in fsList)
         self.assertTrue(os.path.join(mountPath, "base", "dir002",) in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_010(self):
         """
       Attempt to write an image containing a file and a non-empty directory,
@@ -1412,7 +1424,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(os.path.join(mountPath, "base", "dir001", "dir001",) in fsList)
         self.assertTrue(os.path.join(mountPath, "base", "dir001", "dir002",) in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_011(self):
         """
       Attempt to write an image containing several files and a non-empty
@@ -1446,7 +1458,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(os.path.join(mountPath, "base", "dir001", "dir001",) in fsList)
         self.assertTrue(os.path.join(mountPath, "base", "dir001", "dir002",) in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_012(self):
         """
       Attempt to write an image containing a deeply-nested directory.
@@ -1486,7 +1498,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(os.path.join(mountPath, "something", "tree9", "dir002", "dir001",) in fsList)
         self.assertTrue(os.path.join(mountPath, "something", "tree9", "dir002", "dir002",) in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_013(self):
         """
       Attempt to write an image containing only an empty directory, no graft
@@ -1504,7 +1516,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertEqual(1, len(fsList))
         self.assertTrue(mountPath in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_014(self):
         """
       Attempt to write an image containing only an empty directory, with a
@@ -1523,7 +1535,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(mountPath in fsList)
         self.assertTrue(os.path.join(mountPath, "base") in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_015(self):
         """
       Attempt to write an image containing only a non-empty directory, no graft
@@ -1549,7 +1561,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(os.path.join(mountPath, "dir001",) in fsList)
         self.assertTrue(os.path.join(mountPath, "dir002",) in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_016(self):
         """
       Attempt to write an image containing only a non-empty directory, with a
@@ -1577,7 +1589,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(os.path.join(mountPath, "something", "else", "dir001",) in fsList)
         self.assertTrue(os.path.join(mountPath, "something", "else", "dir002",) in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_017(self):
         """
       Attempt to write an image containing only a file, no graft point,
@@ -1596,7 +1608,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(mountPath in fsList)
         self.assertTrue(os.path.join(mountPath, "file001",) in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_018(self):
         """
       Attempt to write an image containing only a file, with a graft point,
@@ -1616,7 +1628,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(os.path.join(mountPath, "point",) in fsList)
         self.assertTrue(os.path.join(mountPath, "point", "file001",) in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_019(self):
         """
       Attempt to write an image containing a file and an empty directory, no
@@ -1637,7 +1649,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(mountPath in fsList)
         self.assertTrue(os.path.join(mountPath, "file001",) in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_020(self):
         """
       Attempt to write an image containing a file and an empty directory, with
@@ -1660,7 +1672,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(os.path.join(mountPath, "base",) in fsList)
         self.assertTrue(os.path.join(mountPath, "other", "file001",) in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_021(self):
         """
       Attempt to write an image containing a file and a non-empty directory,
@@ -1675,7 +1687,7 @@ class TestIsoImage(unittest.TestCase):
         isoImage.addEntry(dir1, contentsOnly=True)
         self.assertRaises(IOError, isoImage.writeImage, imagePath)  # ends up with a duplicate name
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_022(self):
         """
       Attempt to write an image containing several files and a non-empty
@@ -1708,7 +1720,7 @@ class TestIsoImage(unittest.TestCase):
         self.assertTrue(os.path.join(mountPath, "base", "dir001",) in fsList)
         self.assertTrue(os.path.join(mountPath, "base", "dir002",) in fsList)
 
-    @unittest.skipUnless(runAllTests(), "")
+    @unittest.skipUnless(runAllTests(), "Limited test suite")
     def testWriteImage_023(self):
         """
       Attempt to write an image containing a deeply-nested directory,

--- a/tools.ps1
+++ b/tools.ps1
@@ -27,7 +27,7 @@ Switch ($command)
 
     pylint {
       Write-Output "Running pylint checks..." 
-      poetry run pylint --rcfile=.pylintrc src/CedarBackup3 tests
+      poetry run pylint --rcfile=.pylintrc src/CedarBackup3
     }
 }
 

--- a/tools.ps1
+++ b/tools.ps1
@@ -1,0 +1,33 @@
+# Commands for use as IntelliJ or PyCharm external tools on Windows
+#
+# The run script works fine from a Git Bash shell, but isn't easy to invoke
+# from IntelliJ or PyCharm as an external tool.  This script duplicates the
+# behavior from the run script for the things that I want to be able to invoke.
+# It intentionally does *not* duplicate all of the behavior in the run script.
+# For more information, see the notes in DEVELOPER.md.
+#
+# Run like: powershell.exe -executionpolicy bypass -File tools.ps1 format
+
+param([string]$command)
+Switch ($command)
+{
+    format {
+      Write-Output "Running black formatter..." 
+      poetry run black .
+
+      Write-Output "`nRunning isort formatter..." 
+      $files = cmd /c dir /b /a-d /s src\CedarBackup3 tests | findstr \.py$
+      poetry run isort $files
+      Write-Output "done"
+    }
+
+    mypy {
+      Write-Output "There are no MyPy checks for this project"
+    }
+
+    pylint {
+      Write-Output "Running pylint checks..." 
+      poetry run pylint --rcfile=.pylintrc src/CedarBackup3 tests
+    }
+}
+


### PR DESCRIPTION
In the early days of Cedar Backup v2, I did support both Windows and Cygwin.  However, I used the functionality only rarely and I never advertised that it worked - so I don't think end users ever relied on it.   I removed support for both platforms in v3.0.1 as part of the conversion to Python 3.   This PR adds back support for the Windows platform, although I did _not_ add back support for Cygwin at the same time.

Functional changes were fairly minimal - the code had good cross-platform support already.  The two biggest problems were that `os.chown()` and soft links are not supported on Windows.   

The soft links were primarily a problem in the filesystem unit tests.  For the most part, I resolved that by ignoring (skipping) tests that required soft link behavior, rather than reconstructing new expected behavior on the Windows platform.  I did not think the effort was worth it.  Coverage in `filesystem.py` is still pretty decent even without those tests - around 74% on Windows vs. 93% on Linux with the full suite.

While adding `tools.ps1` and setting up the PyCharm development environment, I discovered that the isort formatter had not been run on nested directories like `CedarBackup3.extend`.  So, a large number of the changed files come from fixing that bug in the development process.

While I was in the code making changes, I took the opportunity to clean up the PyCharm inspection profile so the code editor isn't constantly complaining (underlining) errors that I am not going to fix.  I also fixed some minor warnings exposed by PyCharm that are not exposed by pylint.  (This cleanup was mostly in the test suite, which I don't run pylint against, because it's so slow.)