### PR TITLE
Improve debug output for pre/post action hooks

### DIFF
--- a/src/CedarBackup3/cli.py
+++ b/src/CedarBackup3/cli.py
@@ -434,7 +434,7 @@ class _ActionItem(object):
         logger.debug("Executing %s hook for action [%s]: %s", type, hook.action, fields[0:1])
         result, output = executeCommand(command=fields[0:1], args=fields[1:], returnOutput=True)
         if result != 0:
-            logger.debug("Hook failed: %s", "\n".join(output[-10:]))
+            logger.debug("Hook failed, tail is: %s", "\n   %s" % "   ".join(output[-10:]) if output else "<empty>")
             raise IOError("Error (%d) executing %s hook for action [%s]: %s" % (result, type, hook.action, fields[0:1]))
 
 

--- a/src/CedarBackup3/cli.py
+++ b/src/CedarBackup3/cli.py
@@ -432,8 +432,9 @@ class _ActionItem(object):
       """
         fields = splitCommandLine(hook.command)
         logger.debug("Executing %s hook for action [%s]: %s", type, hook.action, fields[0:1])
-        result = executeCommand(command=fields[0:1], args=fields[1:])[0]
+        result, output = executeCommand(command=fields[0:1], args=fields[1:], returnOutput=True)
         if result != 0:
+            logger.debug("Hook failed: %s", "\n".join(output[-10:]))
             raise IOError("Error (%d) executing %s hook for action [%s]: %s" % (result, type, hook.action, fields[0:1]))
 
 

--- a/src/CedarBackup3/util.py
+++ b/src/CedarBackup3/util.py
@@ -1609,6 +1609,7 @@ def executeCommand(command, args, returnOutput=False, ignoreStderr=False, doNotL
                 else:
                     return (pipe.wait(), None)
             except OSError as e:
+                logger.debug("Command returned OSError: %s", e)
                 if returnOutput:
                     if output != []:
                         return (pipe.wait(), output)
@@ -1617,8 +1618,9 @@ def executeCommand(command, args, returnOutput=False, ignoreStderr=False, doNotL
                 else:
                     return (pipe.wait(), None)
     except OSError as e:
+        logger.debug("Command returned OSError: %s", e)
         if returnOutput:
-            return (256, [])
+            return (256, output)
         else:
             return (256, None)
 


### PR DESCRIPTION
While setting up a backup on Windows, I discovered that the debugging process for pre and post action hooks leaves a lot to be desired.  It's hard to see what's happening when a hook fails.  This PR makes some improvements.