### PR TITLE
Use PEP 440 convention for tags

### DIFF
--- a/run
+++ b/run
@@ -183,9 +183,9 @@ run_release() {
    VERSION=$1
    COPYRIGHT="2004-$(date +'%Y')"
    DATE=$(date +'%d %b %Y')
-   TAG="CEDAR_BACKUPV3_V$VERSION"
+   TAG="v$VERSION" # follow PEP 440 naming convention
    FILES="pyproject.toml Changelog src/CedarBackup3/release.py"
-   MESSAGE="Release $VERSION to PyPI"
+   MESSAGE="Release v$VERSION to PyPI"
 
    if [ "$(git branch -a | grep '^\*' | sed 's/^\* //')" != "master" ]; then
       echo "*** You are not on master; you cannot release from this branch"
@@ -194,13 +194,13 @@ run_release() {
 
    git tag -l "$TAG" | grep -q "$TAG"
    if [ $? = 0 ]; then
-      echo "*** Version $VERSION already tagged as $TAG"
+      echo "*** Version v$VERSION already tagged"
       exit 1
    fi
 
    head -1 Changelog | grep -q "^Version $VERSION     unreleased"
    if [ $? != 0 ]; then
-      echo "*** Unreleased version $VERSION is not at the head of the Changelog"
+      echo "*** Unreleased version v$VERSION is not at the head of the Changelog"
       exit 1
    fi
 
@@ -228,18 +228,18 @@ run_release() {
 
    git commit --no-verify -m "$MESSAGE" $FILES
    if [ $? != 0 ]; then
-      echo "*** Commit step failed."
+      echo "*** Commit step failed"
       exit 1
    fi
 
    git tag -a "$TAG" -m "$MESSAGE"
    if [ $? != 0 ]; then
-      echo "*** Tag step failed."
+      echo "*** Tag step failed"
       exit 1
    fi
 
    echo ""
-   echo "*** Version $VERSION has been released and commited; you may publish now"
+   echo "*** Version v$VERSION has been released and commited; you may publish now"
    echo ""
 }
 


### PR DESCRIPTION
Read the Docs has the ability to mark a [stable branch of the documentation](https://docs.readthedocs.io/en/stable/versions.html#:~:text=We%20also%20create%20a%20stable,your%20project%20with%20that%20name.), tied to the most recent tagged release.  However, it only understands tagged versions that follow [PEP 440](https://www.python.org/dev/peps/pep-0440/).   Since Cedar Backup was first developed long before such tagging standards existed (and indeed, before Git itself existed), we have been following a different naming convention.   To complicate things, I was often tagging by hand before I developed a release script, and as a result the tag names are a bit inconsistent.

This PR changes the release process in the `run` script to tag the code following PEP 440.  Then, at the same time, but outside this PR, I made a copy of all the existing tags following the general process in [this answer](https://stackoverflow.com/questions/1028649/how-do-you-rename-a-git-tag) at Stack Overflow.  The old tags still exist, and the new tags point to the same commit as the old tags.  This this makes it possible for Read the Docs to detect the stable releases properly.

```
#!/bin/bash
git tag v3.0.0a1 CEDAR_BACKUPV3_3.0.0a1^{}
git tag v3.0.0a2 CEDAR_BACKUPV3_3.0.0a2^{}
git tag v3.0.1 CEDAR_BACKUPV3_3.0.1^{}
git tag v3.0.2 CEDAR_BACKUPV3_3.0.2^{}
git tag v3.1.0 CEDAR_BACKUPV3_3.1.0^{}
git tag v3.1.1 CEDAR_BACKUP3_V3.1.1^{}
git tag v3.1.2 CEDAR_BACKUPV3_3.1.2^{}
git tag v3.1.3 CEDAR_BACKUPV3_3.1.3^{}
git tag v3.1.4 CEDAR_BACKUPV3_3.1.4^{}
git tag v3.1.5 CEDAR_BACKUPV3_3.1.5^{}
git tag v3.1.6 CEDAR_BACKUPV3_3.1.6^{}
git tag v3.1.7 CEDAR_BACKUP3_V3.1.7^{}
git tag v3.1.8 CEDAR_BACKUP3_V3.1.8^{}
git tag v3.1.9 CEDAR_BACKUPV3_V3.1.9^{}
git tag v3.1.10 CEDAR_BACKUPV3_V3.1.10^{}
git tag v3.1.11 CEDAR_BACKUPV3_V3.1.11^{}
git tag v3.1.12 CEDAR_BACKUPV3_V3.1.12^{}
git tag v3.2.0 CEDAR_BACKUPV3_V3.2.0^{}
git tag v3.3.0 CEDAR_BACKUPV3_V3.3.0^{}
git tag v3.3.1 CEDAR_BACKUPV3_V3.3.1^{}
git tag v3.3.2 CEDAR_BACKUPV3_V3.3.2^{}
git tag v3.3.3 CEDAR_BACKUPV3_V3.3.3^{}
git tag v3.3.4 CEDAR_BACKUPV3_V3.3.4^{}
git tag v3.4.0 CEDAR_BACKUPV3_V3.4.0^{}
git tag v3.4.1 CEDAR_BACKUPV3_V3.4.1^{}
git tag v3.5.0 CEDAR_BACKUPV3_V3.5.0^{}
git tag v3.5.1 CEDAR_BACKUPV3_V3.5.1^{}
git tag v3.5.2 CEDAR_BACKUPV3_V3.5.2^{}
git push --tags
```