### PR TITLE
Improvements to Read the Docs integration

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,4 +37,4 @@ jobs:
         run: poetry install -v
         if: steps.cached-poetry.outputs.cache-hit != 'true'
       - name: Run Tox test suite
-        run: poetry run tox -c .toxrc -e "precommit,docs,{py}-{coverage,nocoverage}"
+        run: poetry run tox -c .toxrc -e "precommit,{py}-{coverage,nocoverage}"

--- a/.toxrc
+++ b/.toxrc
@@ -2,7 +2,6 @@
 isolated_build = true
 envlist = 
    precommit,
-   docs,
    {py}-{coverage,nocoverage}
 ignore_basepython_conflict = true
 
@@ -23,11 +22,3 @@ commands =
    poetry run python -c 'from CedarBackup3.util import Diagnostics; Diagnostics().printDiagnostics(prefix="*** ")'
    poetry run pre-commit run --all-files --show-diff-on-failure
    poetry run pylint --rcfile=.pylintrc src/CedarBackup3
-
-[testenv:docs]
-whitelist_externals = poetry
-changedir = docs
-commands =
-   poetry --version
-   poetry version
-   poetry run sphinx-build -b html -d _build/doctrees . _build/html

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -384,7 +384,7 @@ even via the Git Bash interpreter.  I have created a Powershell script
 
 ### Documentation
 
-Documentation at [Read the Docs](https://cedar-backup3.readthedocs.io/en/latest/)
+Documentation at [Read the Docs](https://cedar-backup3.readthedocs.io/en/stable/)
 is generated via a GitHub hook each time code is pushed to master.  So, there
 is no formal release process for the documentation.
 

--- a/PyPI.md
+++ b/PyPI.md
@@ -2,7 +2,7 @@
 ![](https://img.shields.io/pypi/wheel/cedar-backup3.svg)
 ![](https://img.shields.io/pypi/pyversions/cedar-backup3.svg)
 ![](https://github.com/pronovic/cedar-backup3/workflows/Test%20Suite/badge.svg)
-![](https://readthedocs.org/projects/cedar-backup3/badge/?version=latest&style=flat)
+![](https://readthedocs.org/projects/cedar-backup3/badge/?version=stable&style=flat)
 
 [Cedar Backup](https://github.com/pronovic/cedar-backup3) is a software package
 designed to manage system backups for a pool of local and remote machines.
@@ -16,12 +16,12 @@ beginning of each week.  If your hardware is new enough, Cedar Backup can
 write multisession discs, allowing you to add incremental data to a disc on
 a daily basis.  Alternately, Cedar Backup can write your backups to the Amazon
 S3 cloud rather than relying on physical media.  See 
-the [Cedar Backup v3 Software Manual](https://cedar-backup3.readthedocs.io/en/latest/manual/index.html) for details.
+the [Cedar Backup v3 Software Manual](https://cedar-backup3.readthedocs.io/en/stable/manual/index.html) for details.
 
 Besides offering command-line utilities to manage the backup process, Cedar
 Backup provides a well-organized library of backup-related functionality.
 For more information, see 
-the [API Reference](https://cedar-backup3.readthedocs.io/en/latest/autoapi/index.html).
+the [API Reference](https://cedar-backup3.readthedocs.io/en/stable/autoapi/index.html).
 
 There are many different backup software systems in the open source world.
 Cedar Backup aims to fill a niche: it aims to be a good fit for people who need

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![](https://img.shields.io/pypi/wheel/cedar-backup3.svg)
 ![](https://img.shields.io/pypi/pyversions/cedar-backup3.svg)
 ![](https://github.com/pronovic/cedar-backup3/workflows/Test%20Suite/badge.svg)
-![](https://readthedocs.org/projects/cedar-backup3/badge/?version=latest&style=flat)
+![](https://readthedocs.org/projects/cedar-backup3/badge/?version=stable&style=flat)
 
 ## What is Cedar Backup?
 
@@ -56,7 +56,7 @@ environment, etc.
 See the [Changelog](https://github.com/pronovic/cedar-backup3/blob/master/Changelog) for
 recent changes.
 
-The [Cedar Backup v3 Software Manual](https://cedar-backup3.readthedocs.io/en/latest/manual/index.html) documents 
+The [Cedar Backup v3 Software Manual](https://cedar-backup3.readthedocs.io/en/stable/manual/index.html) documents 
 the process of setting up and using Cedar Backup.  In the manual, you can find
 information about how Cedar Backup works, how to install and configure it, how
 to schedule backups, how to restore data, and how to get support.
@@ -70,7 +70,7 @@ instance: the `IsoImage` class represents an ISO CD image;
 the `CdWriter` class represents a CD-R/CD-RW writer device; and the
 `FilesystemList` class represents a list of files and directories on a
 filesystem.  For more information, see 
-the [API Reference](https://cedar-backup3.readthedocs.io/en/latest/autoapi/index.html) documentation.
+the [API Reference](https://cedar-backup3.readthedocs.io/en/stable/autoapi/index.html) documentation.
 
 ## Package Distributions
 
@@ -83,7 +83,7 @@ $ pip install cedar-backup3
 
 In addition to the Python package, Cedar Backup requires a variety of external 
 system dependencies.  For more information, see 
-the [Cedar Backup v3 Software Manual](https://cedar-backup3.readthedocs.io/en/latest/manual/install.html#installing-the-python-package).
+the [Cedar Backup v3 Software Manual](https://cedar-backup3.readthedocs.io/en/stable/manual/install.html#installing-the-python-package).
     
 Debian packages for Cedar Backup v3, called `cedar-backup3` and
 `cedar-backup3-doc`, were first available starting with the Debian 'stretch'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,8 +15,8 @@ Release v\ |version|
 .. image:: https://github.com/pronovic/cedar-backup3/workflows/Test%20Suite/badge.svg
     :target: https://github.com/pronovic/cedar-backup3
 
-.. image:: https://readthedocs.org/projects/cedar-backup3/badge/?version=latest&style=flat
-    :target: https://cedar-backup3.readthedocs.io/en/latest/
+.. image:: https://readthedocs.org/projects/cedar-backup3/badge/?version=stable&style=flat
+    :target: https://cedar-backup3.readthedocs.io/en/stable/
 
 Cedar Backup is a software package designed to manage system backups for a pool
 of local and remote machines. 

--- a/run
+++ b/run
@@ -139,7 +139,7 @@ run_tox() {
       run_install
    fi
 
-   poetry run tox -c .toxrc -e "precommit,docs,{py}-{coverage,nocoverage}"
+   poetry run tox -c .toxrc -e "precommit,{py}-{coverage,nocoverage}"
 }
 
 # Build the Sphinx documentation for cedar-backup3.readthedocs.io


### PR DESCRIPTION
Read the Docs now offers a config option to build pull requests. The generated documentation is removed 90 days after the branch is deleted. Since I've run into cases where the docs built correctly in the Tox test suite but failed at Read the Docs itself, it seems better to rely on the official Read the Docs build as the merge gate.

At the same time, I adjusted configuration to properly use the stable branch at Read the Docs (which always points at the most recent tagged release), so I converted all of the links to use that URL.   This was facilitated by PR #6, where I converted to use the PEP 440 naming convention for tags.