### PR TITLE
Improvements to Pylint configuration

### DIFF
--- a/run
+++ b/run
@@ -27,7 +27,7 @@ run_pylint() {
       run_install
    fi
 
-   poetry run pylint --rcfile=.pylintrc src/CedarBackup3
+   poetry run pylint src/CedarBackup3
 }
 
 # Run the black code formatter

--- a/run
+++ b/run
@@ -27,7 +27,7 @@ run_pylint() {
       run_install
    fi
 
-   poetry run pylint src/CedarBackup3
+   poetry run pylint -j 0 src/CedarBackup3
 }
 
 # Run the black code formatter

--- a/tools.ps1
+++ b/tools.ps1
@@ -26,7 +26,7 @@ Switch ($command)
 
     pylint {
       Write-Output "Running pylint checks..." 
-      poetry run pylint src/CedarBackup3
+      poetry run pylint -j 0 src/CedarBackup3
     }
 }
 

--- a/tools.ps1
+++ b/tools.ps1
@@ -26,7 +26,7 @@ Switch ($command)
 
     pylint {
       Write-Output "Running pylint checks..." 
-      poetry run pylint --rcfile=.pylintrc src/CedarBackup3
+      poetry run pylint src/CedarBackup3
     }
 }
 


### PR DESCRIPTION
Since the Pylint command line is scattered in several different places (`run`, `tools.ps1`, `.pre-commit-config.yaml`), there's a benefit to having it be as simple as possible.   This PR removes `-rcfile=.pylintrc` command-line switch for pylint, since we already use standard config file.  Unfortunately, Pylint does not offer a way to configure the list of in-scope files except on the command line. 

At the same time as the other change, I also added `-j 0` to the pylint command line, which is supposed to tell Pylint to parallelize its scan up to the number of available CPUs.  This makes a pretty big difference in the scan speed.