### PR TITLE
Change the way archive filenames are generated to eliminate leading '-' characters

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,5 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <settings>
+    <option name="PROJECT_PROFILE" value="Default" />
     <option name="USE_PROJECT_PROFILE" value="false" />
     <version value="1.0" />
   </settings>

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 3.6.0     unreleased
+
+    * Change the way archive filenames are generated to eliminate leading '-' characters.
+
 Version 3.5.4     17 Jan 2021
 
 	* Fix a couple of links in docs/index.rst (cut-and-paste error).

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4120,7 +4120,7 @@ class TestFunctions(unittest.TestCase):
         Test for "/"
         """
         path = "/"
-        expected = "-"
+        expected = "_"
         actual = buildNormalizedPath(path)
         self.assertEqual(expected, actual)
 
@@ -4129,7 +4129,7 @@ class TestFunctions(unittest.TestCase):
         Test for "\\"
         """
         path = "\\"
-        expected = "-"
+        expected = "_"
         actual = buildNormalizedPath(path)
         self.assertEqual(expected, actual)
 
@@ -4220,6 +4220,33 @@ class TestFunctions(unittest.TestCase):
         """
         path = "/Big Nasty Base Path With Spaces/something/else/space s/file.  log   .2 ."
         expected = "Big_Nasty_Base_Path_With_Spaces-something-else-space_s-file.__log___.2_."
+        actual = buildNormalizedPath(path)
+        self.assertEqual(expected, actual)
+
+    def testBuildNormalizedPath018(self):
+        """
+        Test for Windows path with drive letter and slashes.
+        """
+        path = "c:/Users/pronovic/projects/repos"
+        expected = "c-Users-pronovic-projects-repos"
+        actual = buildNormalizedPath(path)
+        self.assertEqual(expected, actual)
+
+    def testBuildNormalizedPath019(self):
+        """
+        Test for Windows path with drive letter and backslashes.
+        """
+        path = r"c:\Users\pronovic\projects\repos"
+        expected = "c-Users-pronovic-projects-repos"
+        actual = buildNormalizedPath(path)
+        self.assertEqual(expected, actual)
+
+    def testBuildNormalizedPath020(self):
+        """
+        Test for path with embedded colon.
+        """
+        path = "/path/to/whatever/key:value"
+        expected = "path-to-whatever-key_value"
         actual = buildNormalizedPath(path)
         self.assertEqual(expected, actual)
 


### PR DESCRIPTION
CedarBackup uses the `util.buildNormalizedPath()` function to translate a path into a filename.  This is how the tar filenames are generated, for instance by translating `/users/pronovic/archives` to `users-pronovic-archives.tar.gz`.  This translation mechanism is suboptimal, because it sometimes results in filenames that start with a `-` character.   Files that start with `-` are difficult to use, because the leading `-` tends to be interpreted as a switch by a lot of UNIX commands.   

The biggest culprit here is drive letters on Windows, where a path like `c:/Users/pronovic/whatever` gets converted to `-Users-pronovic-whatever.tar.gz`.  This is due to an unexpected interaction between `buildNormalizedPath()` (which gives `c:-Users-pronovic-whatever.tar.gz`) and `os.path.join()` (which strips any drive letters from paths that it joins).   The fix is to treat colons a little differently to avoid problems.  

This PR makes the following changes to `buildNormalizedPath()`:

1. The special case for the `/` or `\` path is changed so this path gets converted to `_` rather than `-`
1. A new special case for Windows drive letters is added, so for example a leading `c:/` gets converted to `c-`
1. Any remaining `:` characters are converted to `_`, much like whitespace