### PR TITLE
Set cache key based on actual Python version

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,7 +36,7 @@ jobs:
           python -c "import sys;print('Python %s' % sys.version)"
           echo "PYTHON_VERSION=$(python --version | sed 's/^Python //')" >> "$GITHUB_ENV"
       - name: Install Poetry
-        uses: snok/install-poetry@v1.2.1 # see https://github.com/snok/install-poetry
+        uses: snok/install-poetry@v1.3.1 # see https://github.com/snok/install-poetry
         with:
           version: ${{ env.POETRY_VERSION }}
           virtualenvs-create: true

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -29,11 +29,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
-      - name: Platform information
+      - name: Python platform information
         shell: bash
         run: |
-          # Show platform information
+          # Python platform information
           python -c "import sys;print('Python %s' % sys.version)"
+          echo "PYTHON_VERSION=$(python --version | sed 's/^Python //')" >> "$GITHUB_ENV"
       - name: Install Poetry
         uses: snok/install-poetry@v1.2.1 # see https://github.com/snok/install-poetry
         with:
@@ -49,7 +50,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ matrix.python }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
         shell: bash
         run: |


### PR DESCRIPTION
Currently, the dependency cache key uses the `matrix.python` value, which is `3.8`, `3.9`, `3.10`, etc.  However, when Poetry sets up a the virtualenv, it's for a particular Python version (say `3.10.6`).  If the Python version changes (say, to `3.10.7`), the cache is no longer valid, because the Python executable can no longer be found.  The fix is to set the cache key based on the actual Python version that was used to create the virtualenv, and not the matrix Python version.