### PR TITLE
Improvements to metadata to better support the Debian build process

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 3.7.1     unreleased
+
+	* Improvements to metadata to better support the Debian build process.
+
 Version 3.7.0     29 Dec 2022
 
 	* Drop support for Python 3.7.

--- a/src/CedarBackup3/release.py
+++ b/src/CedarBackup3/release.py
@@ -25,21 +25,29 @@ Attributes:
    AUTHOR: Author of software
    EMAIL: Email address of author
    VERSION: Software version
-   URL: URL of Cedar Backup webpage
 
 :author: Kenneth J. Pronovici <pronovic@ieee.org>
 """
 
-# Historically, this information was tracked directly within this file as
-# part of the release process.  In modern Python, it's better to rely on
-# the package metadata, which is managed by Poetry on our behalf.  We used
-# to track release date and copyright date range, but that information is
-# not available in the package metadata.
+# Historically, this information was tracked directly within this file as part of the
+# release process.  In modern Python, it's better to rely on the package metadata, which
+# is managed by Poetry on our behalf.
+#
+# The metadata will always be set any time the package has been completely and properly
+# installed.  However, there are other cases where it won't be available, such as during
+# the Debian build process, when we are trying to run the test suite from within the
+# source tree.  So, default values are provided.
+#
+# Note: previously, we also tracked release date and copyright date range, but that
+# information is not available in the package metadata.  These values are maintained to
+# avoid breaking the public interface, but are always "unset".
 
 from importlib.metadata import metadata
 
-METADATA = metadata("cedar-backup3")
-AUTHOR = METADATA["Author"]
-EMAIL = METADATA["Author-email"]
-VERSION = METADATA["Version"]
-URL = METADATA["Home-page"]
+_METADATA = metadata("cedar-backup3")
+AUTHOR = _METADATA["Author"] if "Author" in _METADATA else "unset"
+EMAIL = _METADATA["Author-email"] if "Author-email" in _METADATA else "unset"
+VERSION = _METADATA["Version"] if "Version" in _METADATA else "0.0.0"
+COPYRIGHT = "unset"
+DATE = "unset"
+URL = "unset"

--- a/src/CedarBackup3/release.py
+++ b/src/CedarBackup3/release.py
@@ -25,6 +25,7 @@ Attributes:
    AUTHOR: Author of software
    EMAIL: Email address of author
    VERSION: Software version
+   URL: Homepage URL
 
 :author: Kenneth J. Pronovici <pronovic@ieee.org>
 """

--- a/src/CedarBackup3/release.py
+++ b/src/CedarBackup3/release.py
@@ -35,9 +35,8 @@ Attributes:
 # is managed by Poetry on our behalf.
 #
 # The metadata will always be set any time the package has been completely and properly
-# installed.  However, there are other cases where it won't be available, such as during
-# the Debian build process, when we are trying to run the test suite from within the
-# source tree.  So, default values are provided.
+# installed.  However, there are other cases where it won't be available, such as when
+# running the smoke test during the Debian build process. So, default values are provided.
 #
 # Note: previously, we also tracked release date and copyright date range, but that
 # information is not available in the package metadata.  These values are maintained to

--- a/src/CedarBackup3/release.py
+++ b/src/CedarBackup3/release.py
@@ -45,9 +45,11 @@ Attributes:
 from importlib.metadata import metadata
 
 _METADATA = metadata("cedar-backup3")
+
 AUTHOR = _METADATA["Author"] if "Author" in _METADATA else "unset"
 EMAIL = _METADATA["Author-email"] if "Author-email" in _METADATA else "unset"
 VERSION = _METADATA["Version"] if "Version" in _METADATA else "0.0.0"
+URL = _METADATA["Home-page"] if "Home-page" in _METADATA else "unset"
+
 COPYRIGHT = "unset"
 DATE = "unset"
-URL = "unset"


### PR DESCRIPTION
The Debian build process does not have a fully-installed version of the software, so the new metadata added in PR #32 doesn't exist.  It's always there when the package is installed from a wheel, via pip, or via the Debian package manager, just not when trying to run the unit test suite from the source tree when _building_ the Debian package.  This PR adds default values that let the test suite pass, verified by manually making the equivalent change in the Debian source tree for 3.7.0-1.

At the same time, I also put back default values for some of the other fields that aren't available in the metadata, just to avoid breaking the interface.  It's not likely that anyone else is using these fields, but this is more strictly compliant with the minor semver bump from 3.6.x to 3.7.x.