### PR TITLE
More improvements to metadata for the Debian CI test process

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 3.7.2     unreleased
+
+	* More improvements to metadata for the Debian CI test process.
+
 Version 3.7.1     30 Dec 2022
 
 	* Improvements to metadata to better support the Debian build process.

--- a/src/CedarBackup3/release.py
+++ b/src/CedarBackup3/release.py
@@ -36,7 +36,9 @@ Attributes:
 #
 # The metadata will always be set any time the package has been completely and properly
 # installed.  However, there are other cases where it won't be available, such as when
-# running the smoke test during the Debian build process. So, default values are provided.
+# running the smoke tests during the Debian build process, or when running the unit tests
+# from within the source tree as a part of the Debian CI suite. So, default values are
+# provided.
 #
 # Note: previously, we also tracked release date and copyright date range, but that
 # information is not available in the package metadata.  These values are maintained to
@@ -44,7 +46,10 @@ Attributes:
 
 from importlib.metadata import metadata
 
-_METADATA = metadata("cedar-backup3")
+try:
+    _METADATA = metadata("cedar-backup3")
+except ImportError:
+    _METADATA = {}
 
 AUTHOR = _METADATA["Author"] if "Author" in _METADATA else "unset"
 EMAIL = _METADATA["Author-email"] if "Author-email" in _METADATA else "unset"


### PR DESCRIPTION
I tested the changes in PR #33 during the Debian build process, but then unfortunately ran into similar problems when executing the Debian CI test suite.   