### PR TITLE
Upgrade to gha-shared-workflows@v7 with publish improvements

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -16,34 +16,32 @@ concurrency:
 jobs:
   linux-build-and-test:
     name: "Linux"
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v6
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v7
     secrets: inherit
     with:
       matrix-os-version: "[ 'ubuntu-latest' ]"
       matrix-python-version: "[ '3.10', '3.11', '3.12', '3.13' ]"  # run Linux tests on all supported Python versions
       enable-coveralls: true  # only report to coveralls.io for tests that run on Linux
+      persist-python-version: "3.10"  # persist artifacts for the oldest supported Python version
   macos-build-and-test:
     name: "MacOS"
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v6
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v7
     secrets: inherit
     with:
       matrix-os-version: "[ 'macos-latest' ]"
       matrix-python-version: "[ '3.13' ]"  # only run MacOS tests on latest Python
-      enable-coveralls: false 
   windows-build-and-test:
     name: "Windows"
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v6
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v7
     secrets: inherit
     with:
       matrix-os-version: "[ 'windows-latest' ]"
       matrix-python-version: "[ '3.13' ]"  # only run Windows tests on latest Python
-      enable-coveralls: false 
   release:
     name: "Release"
     if: github.ref_type == 'tag'
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-release.yml@v6
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-release.yml@v7
     needs: [ linux-build-and-test, macos-build-and-test, windows-build-and-test ]
     secrets: inherit
     with:
-      python-version: "3.10"   # run release with oldest supported Python version
       publish-pypi: true

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 3.8.3     unreleased
+
+	* Upgrade to gha-shared-workflows@v7 with publish improvements.
+
 Version 3.8.2     15 Oct 2024
 
 	* Pull in latest updates from run-script-framework.


### PR DESCRIPTION
This work was prototyped in a [series of commits in the apologies repo](https://github.com/pronovic/apologies/compare/v0.1.50..v0.1.54).