### PR TITLE
Set $SOURCE_DATE_EPOCH on build so sdist contents get sane timestamps

### DIFF
--- a/.run/commands/poetrybuild.sh
+++ b/.run/commands/poetrybuild.sh
@@ -1,6 +1,13 @@
 # vim: set ft=bash ts=3 sw=3 expandtab:
 # Build release artifacts into the dist/ directory
 
+# Poetry v2 attaches the epoch timestamp (1970-01-01 00:00) to all of the files
+# in the sdist .tar.gz file, rather than the timestamp from the filesystem they
+# were sourced from, as was the behavior in Poetry v1.  To work around this, I'm
+# setting the $SOURCE_DATE_EPOCH to the current UTC epoch seconds value.
+# 
+# See also: https://github.com/python-poetry/poetry/issues/10083
+
 command_poetrybuild() {
    echo "Building release artifacts..."
 
@@ -8,7 +15,7 @@ command_poetrybuild() {
 
    poetry version
 
-   poetry build
+   SOURCE_DATE_EPOCH=$(TZ=UTC date "+%s") poetry build
    if [ $? != 0 ]; then
       echo "*** Build failed"
       exit 1

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 3.9.2     unreleased
+
+	* Set $SOURCE_DATE_EPOCH on build so sdist contents get sane timestamps.
+
 Version 3.9.1     10 Jan 2025
 
 	* Pull in latest version of run-script-framework.


### PR DESCRIPTION
Poetry v2 attaches the epoch timestamp (1970-01-01 00:00) to all of the files in the sdist .tar.gz file, rather than the timestamp from the filesystem they were sourced from, as was the behavior in Poetry v1.  To work around this, I'm
setting the `$SOURCE_DATE_EPOCH` to the current UTC epoch seconds value.

See also: [poetry issue #10083](https://github.com/python-poetry/poetry/issues/10083)