### PR TITLE
Add Sphinx configuration path to .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,6 @@
 version: 2
+sphinx:
+  configuration: docs/conf.py
 build:
   os: ubuntu-24.04
   tools:

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 Version 3.9.2     unreleased
 
+	* Add Sphinx configuration path to .readthedocs.yml.
 	* Set $SOURCE_DATE_EPOCH on build so sdist contents get sane timestamps.
 
 Version 3.9.1     10 Jan 2025


### PR DESCRIPTION
See: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/