### PR TITLE
use importlib.metadata on Debian Trixie

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,10 @@
 import os
 import sys
 from pathlib import Path
-from importlib_metadata import metadata
+try:
+    from importlib_metadata import metadata
+except ImportError:
+    from importlib.metadata import metadata
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ readme = "PyPI.md"
 dynamic = [ "classifiers", "version" ]
 dependencies = [
    "chardet (>=5.2.0,<6.0.0)",            # Debian trixie has 5.2.0
-   "importlib-metadata (>=8.5.0,<9.0.0)", # Debian trixie has 8.5.0
+   "importlib-metadata (>=8.5.0,<9.0.0); python_version <= '3.12'", # Debian trixie has 8.5.0
 ]
 
 [project.urls]

--- a/src/CedarBackup3/release.py
+++ b/src/CedarBackup3/release.py
@@ -44,7 +44,10 @@ Attributes:
 # information is not available in the package metadata.  These values are maintained to
 # avoid breaking the public interface, but are always "unset".
 
-from importlib_metadata import metadata
+try:
+    from importlib_metadata import metadata
+except:
+    from importlib.metadata import metadata
 
 try:
     _METADATA = metadata("cedar-backup3")


### PR DESCRIPTION
Hi,

You seems to care specificaly about Debian ! Great

It looks like `importlib_metadata` could be dropped from Debian before the next release
two years down the road. Please consider this patch. I'm not sure about the pyproject.toml syntax

https://wiki.debian.org/Python/Backports