### PR TITLE
Remove importlib-metadata dependency in favor of standard library

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,7 @@ Version 3.9.3     unreleased
 	* Adjust GHA build process to allow builds for stacked PRs.
 	* Add a new `run clean` target to clean up generated data.
 	* Replace black and isort tools with the Ruff formatter.
+	* Remove importlib-metadata dependency in favor of standard library.
 	* Update the jinja2 transitive dependency to address CVE-2025-27516.
 	* Update the requests transitive dependency to address CVE-2024-47081.
 	* Update the urllib3 transitive dependency to address CVE-2025-50181.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@
 import os
 import sys
 from pathlib import Path
-from importlib_metadata import metadata
+from importlib.metadata import metadata
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/poetry.lock
+++ b/poetry.lock
@@ -375,30 +375,6 @@ files = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.5.0"
-description = "Read metadata from Python packages"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b"},
-    {file = "importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"},
-]
-
-[package.dependencies]
-zipp = ">=3.20"
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-perf = ["ipython"]
-test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
-type = ["pytest-mypy"]
-
-[[package]]
 name = "isort"
 version = "5.13.2"
 description = "A Python utility / library to sort Python imports."
@@ -1025,30 +1001,10 @@ platformdirs = ">=3.9.1,<5"
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
-[[package]]
-name = "zipp"
-version = "3.21.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.9"
-groups = ["main"]
-files = [
-    {file = "zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"},
-    {file = "zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4"},
-]
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
-type = ["pytest-mypy"]
-
 [extras]
 docs = ["sphinx", "sphinx-autoapi"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "8e6f5a24713b9a8cd758e7713179975335a050f55a114cea11f789090e7c4564"
+content-hash = "9ff06687b22abb053dd8ea8d96bccac6eaed600edecbb21ee180768ff5f946b9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,7 @@ license = "GPL-2.0-only"
 readme = "PyPI.md"
 dynamic = [ "classifiers", "version" ]
 dependencies = [
-   "chardet (>=5.2.0,<6.0.0)",            # Debian trixie has 5.2.0
-   "importlib-metadata (>=8.5.0,<9.0.0)", # Debian trixie has 8.5.0
+   "chardet (>=5.2.0,<6.0.0)",  # Debian trixie has 5.2.0
 ]
 
 [project.urls]

--- a/src/CedarBackup3/release.py
+++ b/src/CedarBackup3/release.py
@@ -44,7 +44,7 @@ Attributes:
 # information is not available in the package metadata.  These values are maintained to
 # avoid breaking the public interface, but are always "unset".
 
-from importlib_metadata import metadata
+from importlib.metadata import metadata
 
 try:
     _METADATA = metadata("cedar-backup3")


### PR DESCRIPTION
Based on [the docs](https://docs.python.org/3/library/importlib.metadata.html), `importlib.metadata` is "no longer provisional" as of Python 3.10. Looking back at the commit history, I added this dependency back in late 2022, when I was supporting Python 3.8.  I don't need it any more, and I can rely on the standard library instead.