### PR TITLE
Add support for Visual Studio Code as an IDE

### DIFF
--- a/.run/commands/pytest.sh
+++ b/.run/commands/pytest.sh
@@ -39,8 +39,7 @@ command_pytest() {
    fi
 
    if [ $coverage == "yes" ]; then
-      run_command uvrun coverage run -m pytest --testdox --force-testdox $color $tests
-      run_command uvrun coverage report
+      run_command uvrun pytest --cov=. --testdox --force-testdox $color $tests
       run_command uvrun coverage lcov -o .coverage.lcov
       if [ $html == "yes" ]; then
          run_command uvrun coverage html -d .htmlcov

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debug Tests",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "purpose": ["debug-test"],
+            "console": "integratedTerminal",
+            "justMyCode": false
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,53 @@
+{
+    "python.testing.unittestEnabled": true,
+    "python.testing.pytestEnabled": false,
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.tabSize": 4,
+        "editor.insertSpaces": true,
+        "editor.rulers": [132]
+    },
+    "mypy-type-checker.importStrategy": "fromEnvironment",
+    "files.exclude": {
+        "LICENSE": true,
+        "NOTICE": true,
+        "PyPI.md": true,
+        "SECURITY.md": true,
+        "build": true,
+        "dist": true,
+        "docs/.gitignore": true,
+        "docs/.sphinxignore": true,
+        "docs/_build": true,
+        "docs/_static": true,
+        "docs/_themes": true,
+        "docs/make.bat": true,
+        "docs/Makefile": true,
+        "out": true,
+        "run": true,
+        "uv.lock": true,
+        ".coverage": true,
+        ".coverage.lcov": true,
+        ".coveragerc": true,
+        ".gitattributes": true,
+        ".github": true,
+        ".gitignore": true,
+        ".htmlcov": true,
+        ".idea": true,
+        ".mypy_cache": true,
+        ".pre-commit-config.yaml": true,
+        ".pytest_cache": true,
+        ".python-version": true,
+        ".readthedocs.yaml": true,
+        ".ruff_cache": true,
+        ".run": true,
+        ".tabignore": true,
+        ".venv": true,
+        "**/__pycache__": true
+    },
+    "python.testing.unittestArgs": [
+        "-s",
+        ".",
+        "-p",
+        "test_*.py"
+    ]
+}

--- a/Changelog
+++ b/Changelog
@@ -1,7 +1,8 @@
 Version 3.12.1     unreleased
 
-	* Fix windows commands for external tools.
+	* Fix windows commands for external tools with PyCharm.
 	* Fix Sphinx autoapi to generate docs for source, not tests.
+	* Add support for Visual Studio Code as an IDE.
 
 Version 3.12.0     24 Sep 2025
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -85,18 +85,66 @@ To run scripts, use UV directly:
 These are the exact scripts published by UV as part of the Python package.
 ```
 
-## Integration with PyCharm
+## Integration with Visual Studio Code
 
-Currently, I use [PyCharm Community Edition](https://www.jetbrains.com/pycharm/download) as
-my day-to-day IDE.  By integrating the `run` script to execute Ruff,
-most everything important that can be done from a shell environment can also be
-done right in PyCharm.
+Visual Studio Code does a good job of separating user preferences from
+workspace (or project) preferences, so workspace preferences are checked
+into `.vscode/settings.json`.  The only thing you really need to configure
+is the interpreter.
+
+### Prerequisites
+
+Before going any further, make sure sure that you have installed UV and have a
+working bash shell.  Then, run the suite and confirm that everything is working:
+
+```
+./run suite
+```
+
+### Open the Project
+
+Once you have a working shell development environment, open the `cedar-backup3` 
+directory in the IDE (i.e. `code .`).
+
+### Interpreter
+
+Go to the command palette and search for `interpreter`.  Choose  **Python:
+Select Interpreter**, then select the interpreter executable in the workspace.
+This will be `.venv\Scripts\python.exe` on Windows, or `.venv/bin/python` on
+Linux or MacOS.
+
+### Running Unit Tests
+
+Project configuration in `.vscode/settings.json` should configure the tests
+properly.  You can right click on `src/tests` in the explorer and run tests
+from there, or do something similar for individual directories or `.py` files.
+Workspace configuration includes a `launch.json` that should allow you to
+run unit tests in the debugger.
+
+### Plugins
+
+Workspace configuration in `.vscode/settings.json` assumes that you have installed
+the following plugins:
+
+- [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
+- [Ruff](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff)
+
+The Ruff and linter will run automatically on any file that you open, while you
+are editing the file. Language errors and linter warnings all show up in the
+**Problems** view.
+
+Ruff is set up as the default workspace formatter for `[python]` code.  If you
+want, you can configure Ruff to format code and optimize imports on save, or
+you can run those actions manually.  (For instance, on Windows **SHIFT-ALT-F**
+will format code using Ruff, and **SHIFT-ALT-O** will organize imports.)  
+
+## Integration with PyCharm
 
 PyCharm offers a good developer experience.  However, the underlying configuration
 on disk mixes together project policy (i.e. preferences about which test runner to
-use) with system-specific settings (such as the name and version of the active Python
-interpreter). This makes it impossible to commit complete PyCharm configuration
-to the Git repository.  Instead, the repository contains partial configuration, and
+use) with system-specific settings (such as the name and version of the active Python 
+interpreter). This makes it impossible to commit complete PyCharm configuration 
+to the Git repository.  Instead, the repository contains partial configuration, and 
 there are instructions below about how to manually configure the remaining items.
 
 ### Prerequisites


### PR DESCRIPTION
For a variety of reasons, I've begun the process of transitioning away from PyCharm to Visual Studio Code.  This adds support for Visual Studio Code, capturing workspace settings and updating documentation.  Based on prototype work in [apologies PR #82](https://github.com/pronovic/apologies/pull/82).